### PR TITLE
Feat/bch 768 add tasks to findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,11 @@
     "vite-plugin-vue-devtools": "^7.6.8",
     "vitest": "^2.1.5",
     "vue-tsc": "^2.1.10"
+  },
+  "prettier": {
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "arrowParens": "always"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { RouterView } from 'vue-router'
+import { RouterView } from 'vue-router';
 </script>
 
 <template>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -2,39 +2,55 @@
   <teleport to="body">
     <div
       class="relative z-10"
-      :aria-labelledby="props.title"
+      :aria-labelledby="title"
       role="dialog"
       aria-modal="true"
       v-if="show"
     >
       <div
-        class="fixed inset-0 bg-gray-500/75 transition-opacity"
+        class="fixed inset-0 h-screen w-screen overflow-auto z-1"
         aria-hidden="true"
-      ></div>
-
-      <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+      >
+        <div class="bg-gray-500/70 fixed left-0 top-0 w-screen h-screen z-10" @click.prevent="$emit('close')" />
         <div
-          class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
+          :class="'relative z-20 mx-auto my-12 bg-white rounded-md shadow-xl overflow-hidden ' + sizeClass"
+          v-bind="$attrs"
         >
-          <div
-            class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:max-w-3xl"
-          >
-            <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-              <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                <slot></slot>
-              </div>
-            </div>
-          </div>
+            <slot></slot>
         </div>
       </div>
+
     </div>
   </teleport>
 </template>
 
 <script setup lang="ts">
-const props = defineProps(['title']);
-const show = defineModel('show', {
-  required: true,
-  default: false,
+import { ref } from 'vue'
+
+defineOptions({
+  inheritAttrs: false
+})
+const props = defineProps({
+  title: String,
+  show: Boolean,
+  size: String,
 });
+defineEmits(['close'])
+
+const getSizeClass = () => {
+  const size = props.size as string
+  const sizes: {[size: string]: string} = {
+    'sm': 'w-1/4',
+    'md': 'w-1/3',
+    'lg': 'w-1/2',
+  }
+  if (size) {
+    if (sizes.hasOwnProperty(size)) {
+      return sizes[size];
+    }
+  }
+  return sizes['md'];
+};
+
+const sizeClass = ref(getSizeClass());
 </script>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,0 +1,38 @@
+<template>
+  <div
+    class="relative z-10"
+    :aria-labelledby="props.title"
+    role="dialog"
+    aria-modal="true"
+    v-if="show"
+  >
+    <div
+      class="fixed inset-0 bg-gray-500/75 transition-opacity"
+      aria-hidden="true"
+    ></div>
+
+    <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+      <div
+        class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
+      >
+        <div
+          class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:max-w-3xl"
+        >
+          <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+            <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+              <slot></slot>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps(['title']);
+const show = defineModel('show', {
+  required: true,
+  default: false,
+});
+</script>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,32 +1,34 @@
 <template>
-  <div
-    class="relative z-10"
-    :aria-labelledby="props.title"
-    role="dialog"
-    aria-modal="true"
-    v-if="show"
-  >
+  <teleport to="body">
     <div
-      class="fixed inset-0 bg-gray-500/75 transition-opacity"
-      aria-hidden="true"
-    ></div>
-
-    <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+      class="relative z-10"
+      :aria-labelledby="props.title"
+      role="dialog"
+      aria-modal="true"
+      v-if="show"
+    >
       <div
-        class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
-      >
+        class="fixed inset-0 bg-gray-500/75 transition-opacity"
+        aria-hidden="true"
+      ></div>
+
+      <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
         <div
-          class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:max-w-3xl"
+          class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
         >
-          <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-            <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-              <slot></slot>
+          <div
+            class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:max-w-3xl"
+          >
+            <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+              <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                <slot></slot>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </teleport>
 </template>
 
 <script setup lang="ts">

--- a/src/stores/api.ts
+++ b/src/stores/api.ts
@@ -15,11 +15,25 @@ export interface Observation {
   description: string
 }
 
+export interface Activity {
+  id: string
+  title: string
+  description: string
+}
+
+export interface Task {
+  id: string
+  title: string
+  description: string
+  activities: Activity[]
+}
+
 export interface Finding {
   id: string
   title: string
   description: string
   remarks: string
+  tasks: Task[]
   status?: string
 }
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,12 +3,24 @@
   <div class="grid grid-cols-3 gap-4 mt-4">
     <div class="bg-white rounded shadow">
       <div class="px-4 pt-2">
-        <h3 class="text-lg font-semibold text-zinc-600">Compliance over time</h3>
+        <h3 class="text-lg font-semibold text-zinc-600">
+          Compliance over time
+        </h3>
       </div>
       <div class="h-32">
         <LineChart
           :data="{
-            labels: ['Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            labels: [
+              'Apr',
+              'May',
+              'Jun',
+              'Jul',
+              'Aug',
+              'Sep',
+              'Oct',
+              'Nov',
+              'Dec',
+            ],
             datasets: [
               {
                 gradient: {
@@ -73,12 +85,24 @@
     </div>
     <div class="bg-white rounded shadow">
       <div class="px-4 pt-2">
-        <h3 class="text-lg font-semibold text-zinc-600">Compliance over time</h3>
+        <h3 class="text-lg font-semibold text-zinc-600">
+          Compliance over time
+        </h3>
       </div>
       <div class="h-32">
         <BarChart
           :data="{
-            labels: ['Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            labels: [
+              'Apr',
+              'May',
+              'Jun',
+              'Jul',
+              'Aug',
+              'Sep',
+              'Oct',
+              'Nov',
+              'Dec',
+            ],
             datasets: [
               {
                 label: 'Results',
@@ -119,19 +143,19 @@
   </PageCard>
 </template>
 <script setup lang="ts">
-import LineChart from '@/components/charts/LineChart.vue'
-import BarChart from '@/components/charts/BarChart.vue'
-import PageHeader from '@/components/PageHeader.vue'
-import PageCard from '@/components/PageCard.vue'
-import { onMounted, ref } from 'vue'
-import { useApiStore, type Plan } from '@/stores/api.ts'
+import LineChart from '@/components/charts/LineChart.vue';
+import BarChart from '@/components/charts/BarChart.vue';
+import PageHeader from '@/components/PageHeader.vue';
+import PageCard from '@/components/PageCard.vue';
+import { onMounted, ref } from 'vue';
+import { useApiStore, type Plan } from '@/stores/api.ts';
 
-const apiStore = useApiStore()
-const plans = ref<Plan[]>([] as Plan[])
+const apiStore = useApiStore();
+const plans = ref<Plan[]>([] as Plan[]);
 
 onMounted(() => {
   apiStore.getPlans().then((res) => {
-    plans.value = res
-  })
-})
+    plans.value = res;
+  });
+});
 </script>

--- a/src/views/ResultView.vue
+++ b/src/views/ResultView.vue
@@ -6,7 +6,7 @@
     {{ result._id }}
   </PageSubHeader>
   <div class="grid grid-cols-2 gap-4 mt-4">
-    <PageCard @click="toggleObservationsModal">
+    <PageCard>
       <h3 class="text-lg pl-4 mb-4">Observations</h3>
       <div>
         <div
@@ -19,35 +19,18 @@
         </div>
       </div>
     </PageCard>
-    <Modal
-      title="Observations"
-      v-model:show="showObservationsModal"
-      @click="toggleObservationsModal"
-    >
-      <h3 class="text-lg pl-4 mb-4">Observations</h3>
+    <PageCard>
+      <h3 class="text-lg mb-2">Findings</h3>
       <div>
         <div
-          v-for="(observation, index) in result.observations"
-          :key="observation.id"
-          class="px-4 py-2 hover:bg-zinc-100"
-        >
-          <p class="font-semibold">{{ index + 1 }}: {{ observation.title }}</p>
-          <p class="pt-1">Desc: {{ observation.description }}</p>
-        </div>
-      </div>
-    </Modal>
-    <PageCard @click="toggleFindingsModal">
-      <h3 class="text-lg pl-4 mb-4">Findings</h3>
-      <div>
-        <div
-          v-for="(finding, findingIdx) in result.findings"
+          v-for="(finding) in result.findings"
           :key="finding.id"
-          class="p-* px-4 py-2 hover:bg-zinc-100"
+          class="py-4 border-gray-200 last:border-b-0"
         >
-          <p class="font-semibold">{{ findingIdx + 1 }}. {{ finding.title }}</p>
-          <p class="pt-1">Desc: {{ finding.description }}</p>
-          <p v-if="finding.status" :class="['pt-1', 'text-black-800']">
-            Status:
+          <p class="font-medium">
+            {{ finding.title }}
+          </p>
+          <p class="mb-2">
             <span
               :class="[
                 'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
@@ -59,62 +42,19 @@
               {{ finding.status }}
             </span>
           </p>
-          <div class="pt-2 flex items-center justify-between w-full">
-            <p>Tasks: {{ finding.tasks.length }}</p>
-            <span class="mr-5">(Click for more details)</span>
+          <p class="pt-1">{{ finding.description }}</p>
+          <div class="pt-2 flex items-center justify-between mb-2">
+            <button @click="showFindingTasks(finding)" class="px-2 py-1 border-zinc-500 border rounded-md shadow text-sm">View Tasks</button>
           </div>
         </div>
       </div>
     </PageCard>
-    <Modal
-      title="Findings"
-      v-model:show="showFindingsModal"
-      @click="toggleFindingsModal"
-    >
-      <h3 class="text-lg pl-4 mb-4">Findings</h3>
-      <div>
-        <div
-          v-for="(finding, findingIdx) in result.findings"
-          :key="finding.id"
-          class="p-* px-4 py-2 hover:bg-zinc-100"
-        >
-          <p class="font-semibold">{{ findingIdx + 1 }}. {{ finding.title }}</p>
-          <p class="pt-1">Desc: {{ finding.description }}</p>
-          <p v-if="finding.status" :class="['pt-1', 'text-black-800']">
-            Status:
-            <span
-              :class="[
-                'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
-                `bg-${getFindingStatusColor(finding.status)}-50`,
-                `text-${getFindingStatusColor(finding.status)}-800`,
-                `ring-${getFindingStatusColor(finding.status)}-600/20`,
-              ]"
-            >
-              {{ finding.status }}
-            </span>
-          </p>
-          <p class="pt-1">Tasks:</p>
-          <ol class="pl-6 pt-2 list-decimal">
-            <li v-for="task in finding.tasks" :key="task.id">
-              <p class="mb-2">Title: {{ task.title }}</p>
-              <p class="mb-2">Description: {{ task.description }}</p>
-              <p>Activities:</p>
-              <ol class="pl-6 pt-2 list-decimal">
-                <li v-for="activity in task.activities" :key="activity.id">
-                  <p>Title: {{ task.title }}</p>
-                  <p>Description: {{ task.description }}</p>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </div>
-      </div>
-    </Modal>
-    <PageCard @click="toggleLogsModal">
+    <PageCard>
       <h3 class="text-lg pl-4 mb-4">Logs</h3>
       <div>
         <div
           v-for="log in result.assessmentLogEntries"
+          :key="log.title"
           class="px-4 py-2 hover:bg-zinc-100"
         >
           <p class="font-semibold">{{ log.title }}</p>
@@ -122,16 +62,31 @@
         </div>
       </div>
     </PageCard>
-    <Modal title="Logs" v-model:show="showLogsModal" @click="toggleLogsModal">
-      <h3 class="text-lg pl-4 mb-4">Logs</h3>
-      <div>
-        <div
-          v-for="log in result.assessmentLogEntries"
-          class="px-4 py-2 hover:bg-zinc-100"
-        >
-          <p class="font-semibold">{{ log.title }}</p>
-          <p>{{ log.description }}</p>
+
+    <Modal
+      :show="showFindingsModal"
+      @close="setFindingsModal(false)"
+    >
+      <div class="px-12 py-8">
+        <div v-for="task in tasks" :key="task.id">
+          <div class="flex items-center">
+            <div class="bg-blue-500 rounded-full w-3 aspect-square mr-2" />
+            <h4 class="font-medium text-lg">{{ task.title }}</h4>
+          </div>
+          <div class="border-l-4 border-blue-500 ml-1 pl-4 pb-4 pt-2">
+            <div v-for="activity in task.activities" :key="activity.id" class="pb-4 last:pb-0">
+              <h4 class="font-medium">{{ activity.title }}
+                {{ activity.title }}
+              </h4>
+              <div class="text-sm pl-2">
+                {{ activity.description }}
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
+      <div class="border-t border-zinc-300 text-right py-2 px-4">
+        <button @click="setFindingsModal(false)" class="px-2 py-1 border-zinc-500 border rounded-md shadow">Close</button>
       </div>
     </Modal>
   </div>
@@ -143,14 +98,14 @@ import PageHeader from '@/components/PageHeader.vue';
 import PageCard from '@/components/PageCard.vue';
 import PageSubHeader from '@/components/PageSubHeader.vue';
 import Modal from '@/components/Modal.vue';
-import { type Result, useApiStore } from '@/stores/api';
+import { type Finding, type Result, type Task, useApiStore } from '@/stores/api'
 
 const apiStore = useApiStore();
 const route = useRoute();
 const id = route.params.id as string;
 
 const result = ref<Result>({} as Result);
-const showObservationsModal = ref(false);
+const tasks = ref<Task[]>([] as Task[]);
 const showLogsModal = ref(false);
 const showFindingsModal = ref(false);
 
@@ -161,16 +116,13 @@ enum FindingStatusColor {
   RESOLVED = 'green',
 }
 
-function toggleObservationsModal() {
-  showObservationsModal.value = !showObservationsModal.value;
+function showFindingTasks(finding: Finding) {
+  tasks.value = finding.tasks
+  setFindingsModal(true);
 }
 
-function toggleFindingsModal() {
-  showFindingsModal.value = !showFindingsModal.value;
-}
-
-function toggleLogsModal() {
-  showLogsModal.value = !showLogsModal.value;
+function setFindingsModal(open: boolean) {
+  showFindingsModal.value = open;
 }
 
 function getFindingStatusColor(status?: string): string {

--- a/src/views/ResultView.vue
+++ b/src/views/ResultView.vue
@@ -6,7 +6,7 @@
     {{ result._id }}
   </PageSubHeader>
   <div class="grid grid-cols-2 gap-4 mt-4">
-    <PageCard>
+    <PageCard @click="toggleObservationsModal">
       <h3 class="text-lg pl-4 mb-4">Observations</h3>
       <div>
         <div
@@ -14,59 +14,145 @@
           :key="observation.id"
           class="px-4 py-2 hover:bg-zinc-100"
         >
-          <p class="font-semibold">{{index + 1}}: {{ observation.title }}</p>
+          <p class="font-semibold">{{ index + 1 }}: {{ observation.title }}</p>
           <p class="pt-1">Desc: {{ observation.description }}</p>
         </div>
       </div>
     </PageCard>
-    <PageCard>
+    <Modal
+      title="Observations"
+      v-model:show="showObservationsModal"
+      @click="toggleObservationsModal"
+    >
+      <h3 class="text-lg pl-4 mb-4">Observations</h3>
+      <div>
+        <div
+          v-for="(observation, index) in result.observations"
+          :key="observation.id"
+          class="px-4 py-2 hover:bg-zinc-100"
+        >
+          <p class="font-semibold">{{ index + 1 }}: {{ observation.title }}</p>
+          <p class="pt-1">Desc: {{ observation.description }}</p>
+        </div>
+      </div>
+    </Modal>
+    <PageCard @click="toggleFindingsModal">
       <h3 class="text-lg pl-4 mb-4">Findings</h3>
       <div>
-        <div v-for="(finding, idx) in result.findings" :key="finding.id" class="p-* px-4 py-2 hover:bg-zinc-100">
-          <p class="font-semibold">{{idx + 1}}. {{ finding.title }}</p>
+        <div
+          v-for="(finding, findingIdx) in result.findings"
+          :key="finding.id"
+          class="p-* px-4 py-2 hover:bg-zinc-100"
+        >
+          <p class="font-semibold">{{ findingIdx + 1 }}. {{ finding.title }}</p>
           <p class="pt-1">Desc: {{ finding.description }}</p>
-          <p v-if="finding.status" :class="[
-                'pt-1',
-                'text-black-800', 
-              ]">Status:
-            <span 
+          <p v-if="finding.status" :class="['pt-1', 'text-black-800']">
+            Status:
+            <span
               :class="[
-                'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset', 
-                `bg-${getFindingStatusColor(finding.status)}-50`, 
-                `text-${getFindingStatusColor(finding.status)}-800`, 
-                `ring-${getFindingStatusColor(finding.status)}-600/20`
+                'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                `bg-${getFindingStatusColor(finding.status)}-50`,
+                `text-${getFindingStatusColor(finding.status)}-800`,
+                `ring-${getFindingStatusColor(finding.status)}-600/20`,
               ]"
             >
               {{ finding.status }}
             </span>
-        </p>
+          </p>
+          <div class="pt-2 flex items-center justify-between w-full">
+            <p>Tasks: {{ finding.tasks.length }}</p>
+            <span class="mr-5">(Click for more details)</span>
+          </div>
         </div>
       </div>
     </PageCard>
-    <PageCard>
+    <Modal
+      title="Findings"
+      v-model:show="showFindingsModal"
+      @click="toggleFindingsModal"
+    >
+      <h3 class="text-lg pl-4 mb-4">Findings</h3>
+      <div>
+        <div
+          v-for="(finding, findingIdx) in result.findings"
+          :key="finding.id"
+          class="p-* px-4 py-2 hover:bg-zinc-100"
+        >
+          <p class="font-semibold">{{ findingIdx + 1 }}. {{ finding.title }}</p>
+          <p class="pt-1">Desc: {{ finding.description }}</p>
+          <p v-if="finding.status" :class="['pt-1', 'text-black-800']">
+            Status:
+            <span
+              :class="[
+                'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                `bg-${getFindingStatusColor(finding.status)}-50`,
+                `text-${getFindingStatusColor(finding.status)}-800`,
+                `ring-${getFindingStatusColor(finding.status)}-600/20`,
+              ]"
+            >
+              {{ finding.status }}
+            </span>
+          </p>
+          <p class="pt-1">Tasks:</p>
+          <ol class="pl-6 pt-2 list-decimal">
+            <li v-for="task in finding.tasks" :key="task.id">
+              <p class="mb-2">Title: {{ task.title }}</p>
+              <p class="mb-2">Description: {{ task.description }}</p>
+              <p>Activities:</p>
+              <ol class="pl-6 pt-2 list-decimal">
+                <li v-for="activity in task.activities" :key="activity.id">
+                  <p>Title: {{ task.title }}</p>
+                  <p>Description: {{ task.description }}</p>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </Modal>
+    <PageCard @click="toggleLogsModal">
       <h3 class="text-lg pl-4 mb-4">Logs</h3>
       <div>
-        <div v-for="log in result.assessmentLogEntries" class="px-4 py-2 hover:bg-zinc-100">
+        <div
+          v-for="log in result.assessmentLogEntries"
+          class="px-4 py-2 hover:bg-zinc-100"
+        >
           <p class="font-semibold">{{ log.title }}</p>
           <p>{{ log.description }}</p>
         </div>
       </div>
     </PageCard>
+    <Modal title="Logs" v-model:show="showLogsModal" @click="toggleLogsModal">
+      <h3 class="text-lg pl-4 mb-4">Logs</h3>
+      <div>
+        <div
+          v-for="log in result.assessmentLogEntries"
+          class="px-4 py-2 hover:bg-zinc-100"
+        >
+          <p class="font-semibold">{{ log.title }}</p>
+          <p>{{ log.description }}</p>
+        </div>
+      </div>
+    </Modal>
   </div>
 </template>
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-import { useRoute } from 'vue-router'
-import PageHeader from '@/components/PageHeader.vue'
-import PageCard from '@/components/PageCard.vue'
-import PageSubHeader from '@/components/PageSubHeader.vue'
-import { type Result, useApiStore } from '@/stores/api'
+import { onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import PageHeader from '@/components/PageHeader.vue';
+import PageCard from '@/components/PageCard.vue';
+import PageSubHeader from '@/components/PageSubHeader.vue';
+import Modal from '@/components/Modal.vue';
+import { type Result, useApiStore } from '@/stores/api';
 
 const apiStore = useApiStore();
 const route = useRoute();
 const id = route.params.id as string;
 
 const result = ref<Result>({} as Result);
+const showObservationsModal = ref(false);
+const showLogsModal = ref(false);
+const showFindingsModal = ref(false);
 
 enum FindingStatusColor {
   UNKNOWN = 'grey',
@@ -75,8 +161,23 @@ enum FindingStatusColor {
   RESOLVED = 'green',
 }
 
+function toggleObservationsModal() {
+  showObservationsModal.value = !showObservationsModal.value;
+}
+
+function toggleFindingsModal() {
+  showFindingsModal.value = !showFindingsModal.value;
+}
+
+function toggleLogsModal() {
+  showLogsModal.value = !showLogsModal.value;
+}
+
 function getFindingStatusColor(status?: string): string {
-  return FindingStatusColor[status as keyof typeof FindingStatusColor] || FindingStatusColor.UNKNOWN;
+  return (
+    FindingStatusColor[status as keyof typeof FindingStatusColor] ||
+    FindingStatusColor.UNKNOWN
+  );
 }
 
 onMounted(() => {
@@ -85,4 +186,3 @@ onMounted(() => {
   });
 });
 </script>
-


### PR DESCRIPTION
Added ability for cards to display extra information when clicked on in a modal view.

Example: 
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/3c6eca23-3365-4c30-b97f-c6fb2f1c2493" />
