### PR TITLE
Findings by control class name

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -69,6 +69,14 @@ const authenticatedRoutes = [
     component: () => import('../views/FindingsBySubjectSearchView.vue'),
   },
   {
+    path: '/findings/by-class/:className',
+    name: 'findings-by-class',
+    // route level code-splitting
+    // this generates a separate chunk (About.[hash].js) for this route
+    // which is lazy-loaded when the route is visited.
+    component: () => import('../views/FindingsByClassSearchView.vue'),
+  },
+  {
     path: '/about',
     name: 'about',
     component: () => import('../views/AboutView.vue'),

--- a/src/stores/findings.ts
+++ b/src/stores/findings.ts
@@ -44,6 +44,11 @@ export interface FindingBySubject {
   findings: Finding[];
 }
 
+export interface FindingsByClassName {
+  controlid: string;
+  findings: Finding[];
+}
+
 export const useFindingsStore = defineStore('findings', () => {
   const configStore = useConfigStore();
 
@@ -89,6 +94,25 @@ export const useFindingsStore = defineStore('findings', () => {
     }
 
     return (await response.json()) as DataResponse<FindingBySubject[]>;
+  }
+
+  async function getByControlClass(className: string): Promise<DataResponse<FindingsByClassName[]>> {
+    const config = await configStore.getConfig();
+    const response = await fetch(
+      `${config.API_URL}/api/findings/by-control/${className}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Error: ${response.statusText}`);
+    }
+
+    return (await response.json()) as DataResponse<FindingsByClassName[]>;
   }
 
   async function history(uuid: string): Promise<DataResponse<Finding[]>> {
@@ -162,13 +186,12 @@ export const useFindingsStore = defineStore('findings', () => {
   // }
 
   return {
-    // getResult,
     get: get,
     search: search,
-    searchBySubject: searchBySubject,
+    searchBySubject,
     history: history,
     getComplianceForSearch,
     getComplianceForUUID,
-    // getStreamResults,
+    getByControlClass,
   };
 });

--- a/src/views/FindingsHistoryView.vue
+++ b/src/views/FindingsHistoryView.vue
@@ -39,25 +39,6 @@
           :to="{ name: 'finding-view', params: { id: finding._id } }"
         >View</RouterLink>
       </div>
-      <!--        <div class="px-2 py-2 flex-1">{{ assessment.title }}</div>-->
-      <!--        <div class="px-2 w-1/5 h-8">-->
-      <!--          <LineChart-->
-      <!--            :options="{-->
-      <!--              plugins: {-->
-      <!--                tooltip: {-->
-      <!--                  enabled: false,-->
-      <!--                },-->
-      <!--              },-->
-      <!--              elements: {-->
-      <!--                point: {-->
-      <!--                  hoverRadius: 0,-->
-      <!--                  hitRadius: 0,-->
-      <!--                },-->
-      <!--              },-->
-      <!--            }"-->
-      <!--            :data="assessment.data"-->
-      <!--          />-->
-      <!--        </div>-->
     </div>
   </PageCard>
 </template>

--- a/src/views/FindingsSearchView.vue
+++ b/src/views/FindingsSearchView.vue
@@ -48,7 +48,7 @@
     </div>
     <div class="mt-4">
       <div
-        class="flex items-center border-t first:border-none hover:bg-zinc-100 py-2 px-2"
+        class="flex border-t first:border-none hover:bg-zinc-100 py-2 px-2"
         v-for="finding in findings"
         :key="finding.uuid"
       >
@@ -59,7 +59,7 @@
         <div class="flex-wrap grow">
           <LabelList :labels="finding.labels" />
         </div>
-        <div>
+        <div class="flex items-start">
           <RouterLink
             class="bg-gray-50 hover:bg-gray-200 text-blue-800 border border-blue-800 px-4 py-1 rounded-md text-sm mr-2"
             :to="{ name: 'finding-history', params: { uuid: finding.uuid } }"
@@ -81,7 +81,6 @@ import { useRoute, useRouter } from 'vue-router'
 import PageHeader from '@/components/PageHeader.vue'
 import PageCard from '@/components/PageCard.vue'
 import PageSubHeader from '@/components/PageSubHeader.vue'
-import { type LabelMap } from '@/stores/api'
 import { FilterParser } from '@/parsers/labelfilter.ts'
 import { BIconFloppy, BIconSearch } from 'bootstrap-icons-vue'
 import LabelList from '@/components/LabelList.vue'


### PR DESCRIPTION
**UI route:**
`http://localhost:3000/findings/by-class/SAMA_CSF_1.0`

**Things to do after this:**

- Filtering
- Create a GET /findings/control-classes
Returns a list of control classes that are used by findings.
- Create a FE page which lists these - put in sidebar
- Link to this page from there

<img width="1874" alt="Screenshot 2025-04-02 at 14 02 59" src="https://github.com/user-attachments/assets/c41fd6a9-5b2d-4619-8a96-3504019178c5" />
