### PR TITLE
feat(ui): Add Inventory Plus page with comprehensive inventory display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ logs/
 tests_output/
 
 eslint-report.json
+
+# Husky test files
+test-husky.js

--- a/src/components/inventory/InventoryItemCreateForm.vue
+++ b/src/components/inventory/InventoryItemCreateForm.vue
@@ -219,7 +219,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   cancel: [];
-  created: [inventoryItem: any];
+  created: [inventoryItem: InventoryItem];
 }>();
 
 const toast = useToast();
@@ -233,15 +233,25 @@ const selectedAssessmentPlanId = ref('');
 const selectedAssessmentResultsId = ref('');
 const assetType = ref('');
 
+// Type for OSCAL documents with basic metadata
+interface OscalDocument {
+  uuid: string;
+  metadata?: {
+    title?: string;
+  };
+}
+
 // Load available SSPs, POAMs, Assessment Plans, and Assessment Results
-const { data: sspList } = useDataApi<any[]>('/api/oscal/system-security-plans');
-const { data: poamList } = useDataApi<any[]>(
+const { data: sspList } = useDataApi<OscalDocument[]>(
+  '/api/oscal/system-security-plans',
+);
+const { data: poamList } = useDataApi<OscalDocument[]>(
   '/api/oscal/plan-of-action-and-milestones',
 );
-const { data: assessmentPlanList } = useDataApi<any[]>(
+const { data: assessmentPlanList } = useDataApi<OscalDocument[]>(
   '/api/oscal/assessment-plans',
 );
-const { data: assessmentResultsList } = useDataApi<any[]>(
+const { data: assessmentResultsList } = useDataApi<OscalDocument[]>(
   '/api/oscal/assessment-results',
 );
 
@@ -284,7 +294,7 @@ const {
   data: newItem,
   isLoading: saving,
   execute: createItem,
-} = useDataApi<any>(
+} = useDataApi<InventoryItem>(
   null,
   {
     method: 'POST',
@@ -368,12 +378,15 @@ const createInventoryItem = async () => {
       });
       emit('created', newItem.value);
     }
-  } catch (error: any) {
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : 'Failed to create inventory item';
     toast.add({
       severity: 'error',
       summary: 'Error',
-      detail:
-        error?.response?.data?.message || 'Failed to create inventory item',
+      detail: errorMessage,
       life: 3000,
     });
   }

--- a/src/components/inventory/InventoryItemCreateForm.vue
+++ b/src/components/inventory/InventoryItemCreateForm.vue
@@ -1,0 +1,390 @@
+<template>
+  <div class="px-12 py-8">
+    <form @submit.prevent="createInventoryItem()">
+      <h1 class="text-xl font-semibold mb-6 dark:text-slate-300">
+        Create Inventory Item
+      </h1>
+
+      <div class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300"
+          >Destination <span class="text-red-500">*</span></label
+        >
+        <div class="flex gap-2">
+          <select
+            v-model="destination"
+            @change="onDestinationChange"
+            class="flex-1 px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-300"
+            required
+          >
+            <option value="unattached">
+              Unattached (Can be attached later)
+            </option>
+            <option value="ssp">System Security Plan (Production)</option>
+            <option value="poam">Plan of Action & Milestones (Planned)</option>
+            <option value="assessment-plan">Assessment Plan (Discovery)</option>
+            <option value="assessment-results">
+              Assessment Results (Findings)
+            </option>
+          </select>
+        </div>
+        <p
+          v-if="destination === 'unattached'"
+          class="text-sm text-gray-500 dark:text-gray-400 mt-1"
+        >
+          Item will be created without attachment. You can attach it to an SSP
+          or POAM later.
+        </p>
+        <p
+          v-else-if="destination === 'ssp'"
+          class="text-sm text-gray-500 dark:text-gray-400 mt-1"
+        >
+          Item will be immediately added to the active SSP as operational
+          inventory.
+        </p>
+        <p
+          v-else-if="destination === 'poam'"
+          class="text-sm text-gray-500 dark:text-gray-400 mt-1"
+        >
+          Item will be tracked as planned inventory for future implementation.
+        </p>
+        <p
+          v-else-if="destination === 'assessment-plan'"
+          class="text-sm text-gray-500 dark:text-gray-400 mt-1"
+        >
+          Item will be documented as part of assessment planning.
+        </p>
+        <p
+          v-else-if="destination === 'assessment-results'"
+          class="text-sm text-gray-500 dark:text-gray-400 mt-1"
+        >
+          Item will be recorded as discovered during assessment.
+        </p>
+      </div>
+
+      <div v-if="destination === 'ssp' && !props.sspId" class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300">Select SSP</label>
+        <select
+          v-model="selectedSspId"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-300"
+          required
+        >
+          <option value="">Select an SSP...</option>
+          <option
+            v-for="ssp in availableSSPs"
+            :key="ssp.uuid"
+            :value="ssp.uuid"
+          >
+            {{ ssp.metadata?.title || 'Untitled SSP' }}
+          </option>
+        </select>
+      </div>
+
+      <div v-if="destination === 'poam'" class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300"
+          >Select POAM (Optional)</label
+        >
+        <select
+          v-model="selectedPoamId"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-300"
+        >
+          <option value="">No specific POAM...</option>
+          <option
+            v-for="poam in availablePOAMs"
+            :key="poam.uuid"
+            :value="poam.uuid"
+          >
+            {{ poam.metadata?.title || 'Untitled POAM' }}
+          </option>
+        </select>
+      </div>
+
+      <div v-if="destination === 'assessment-plan'" class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300"
+          >Select Assessment Plan (Optional)</label
+        >
+        <select
+          v-model="selectedAssessmentPlanId"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-300"
+        >
+          <option value="">No specific Assessment Plan...</option>
+          <option
+            v-for="ap in availableAssessmentPlans"
+            :key="ap.uuid"
+            :value="ap.uuid"
+          >
+            {{ ap.metadata?.title || 'Untitled Assessment Plan' }}
+          </option>
+        </select>
+      </div>
+
+      <div v-if="destination === 'assessment-results'" class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300"
+          >Select Assessment Results (Optional)</label
+        >
+        <select
+          v-model="selectedAssessmentResultsId"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-300"
+        >
+          <option value="">No specific Assessment Results...</option>
+          <option
+            v-for="ar in availableAssessmentResults"
+            :key="ar.uuid"
+            :value="ar.uuid"
+          >
+            {{ ar.metadata?.title || 'Untitled Assessment Results' }}
+          </option>
+        </select>
+      </div>
+
+      <div class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300">UUID</label>
+        <div class="flex gap-2">
+          <FormInput
+            v-model="inventoryItemData.uuid"
+            placeholder="Inventory Item UUID"
+            class="flex-1"
+            readonly
+          />
+          <button
+            type="button"
+            @click="generateUUID"
+            class="px-3 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 transition-colors"
+          >
+            Generate
+          </button>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300"
+          >Description <span class="text-red-500">*</span></label
+        >
+        <FormTextarea v-model="inventoryItemData.description" required />
+      </div>
+
+      <div class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300">Asset Type</label>
+        <select
+          v-model="assetType"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-300"
+        >
+          <option value="">None</option>
+          <option value="operating-system">Operating System</option>
+          <option value="database">Database</option>
+          <option value="web-server">Web Server</option>
+          <option value="application">Application</option>
+          <option value="network-device">Network Device</option>
+          <option value="container">Container</option>
+          <option value="cloud-service">Cloud Service</option>
+        </select>
+      </div>
+
+      <div class="mb-4">
+        <label class="inline-block pb-2 dark:text-slate-300">Remarks</label>
+        <FormTextarea v-model="inventoryItemData.remarks" />
+      </div>
+
+      <div class="flex justify-end gap-4">
+        <button
+          type="button"
+          @click="$emit('cancel')"
+          class="px-4 py-2 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 rounded-md hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          :disabled="saving"
+          class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 transition-colors"
+        >
+          {{ saving ? 'Creating...' : 'Create Inventory Item' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, onMounted, watch, computed } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import FormInput from '@/components/forms/FormInput.vue';
+import FormTextarea from '@/components/forms/FormTextarea.vue';
+import type { InventoryItem } from '@/stores/system-security-plans.ts';
+import { useDataApi, decamelizeKeys } from '@/composables/axios';
+import { v4 as uuidv4 } from 'uuid';
+
+const props = defineProps<{
+  sspId?: string;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  created: [inventoryItem: any];
+}>();
+
+const toast = useToast();
+
+const destination = ref<
+  'unattached' | 'ssp' | 'poam' | 'assessment-plan' | 'assessment-results'
+>('unattached');
+const selectedSspId = ref('');
+const selectedPoamId = ref('');
+const selectedAssessmentPlanId = ref('');
+const selectedAssessmentResultsId = ref('');
+const assetType = ref('');
+
+// Load available SSPs, POAMs, Assessment Plans, and Assessment Results
+const { data: sspList } = useDataApi<any[]>('/api/oscal/system-security-plans');
+const { data: poamList } = useDataApi<any[]>(
+  '/api/oscal/plan-of-action-and-milestones',
+);
+const { data: assessmentPlanList } = useDataApi<any[]>(
+  '/api/oscal/assessment-plans',
+);
+const { data: assessmentResultsList } = useDataApi<any[]>(
+  '/api/oscal/assessment-results',
+);
+
+const availableSSPs = computed(() => sspList.value || []);
+const availablePOAMs = computed(() => poamList.value || []);
+const availableAssessmentPlans = computed(() => assessmentPlanList.value || []);
+const availableAssessmentResults = computed(
+  () => assessmentResultsList.value || [],
+);
+
+const inventoryItemData = reactive<InventoryItem>({
+  uuid: '',
+  description: '',
+  remarks: '',
+  props: [],
+  links: [],
+  responsibleParties: [],
+  implementedComponents: [],
+});
+
+// Update props when asset type changes
+watch(assetType, (newType) => {
+  if (newType) {
+    // Remove existing asset-type prop
+    inventoryItemData.props =
+      inventoryItemData.props?.filter((p) => p.name !== 'asset-type') || [];
+    // Add new asset-type prop
+    inventoryItemData.props.push({
+      name: 'asset-type',
+      value: newType,
+    });
+  } else {
+    // Remove asset-type prop if cleared
+    inventoryItemData.props =
+      inventoryItemData.props?.filter((p) => p.name !== 'asset-type') || [];
+  }
+});
+
+const {
+  data: newItem,
+  isLoading: saving,
+  execute: createItem,
+} = useDataApi<any>(
+  null,
+  {
+    method: 'POST',
+    transformRequest: [decamelizeKeys],
+  },
+  { immediate: false },
+);
+
+const generateUUID = () => {
+  inventoryItemData.uuid = uuidv4();
+};
+
+const getDestinationName = () => {
+  switch (destination.value) {
+    case 'ssp':
+      return 'System Security Plan';
+    case 'poam':
+      return 'Plan of Action & Milestones';
+    case 'assessment-plan':
+      return 'Assessment Plan';
+    case 'assessment-results':
+      return 'Assessment Results';
+    default:
+      return 'unattached state';
+  }
+};
+
+const onDestinationChange = () => {
+  // Reset selections when destination changes
+  selectedSspId.value = '';
+  selectedPoamId.value = '';
+  selectedAssessmentPlanId.value = '';
+  selectedAssessmentResultsId.value = '';
+
+  // If SSP destination and we have a prop SSP ID, use it
+  if (destination.value === 'ssp' && props.sspId) {
+    selectedSspId.value = props.sspId;
+  }
+};
+
+const createInventoryItem = async () => {
+  try {
+    // Determine destination ID
+    let destinationId = '';
+    if (destination.value === 'ssp') {
+      destinationId = props.sspId || selectedSspId.value;
+      if (!destinationId) {
+        toast.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Please select an SSP',
+          life: 3000,
+        });
+        return;
+      }
+    } else if (destination.value === 'poam') {
+      destinationId = selectedPoamId.value; // Optional for POAM
+    } else if (destination.value === 'assessment-plan') {
+      destinationId = selectedAssessmentPlanId.value; // Optional for Assessment Plan
+    } else if (destination.value === 'assessment-results') {
+      destinationId = selectedAssessmentResultsId.value; // Optional for Assessment Results
+    }
+
+    // Prepare request
+    const request = {
+      destination: destination.value,
+      destination_id: destinationId,
+      inventory_item: inventoryItemData,
+    };
+
+    // Create the item using the new endpoint
+    // Fix: Pass request as data in config object
+    await createItem('/api/oscal/inventory', { data: request });
+
+    if (newItem.value) {
+      toast.add({
+        severity: 'success',
+        summary: 'Success',
+        detail: `Inventory item created in ${getDestinationName()}`,
+        life: 3000,
+      });
+      emit('created', newItem.value);
+    }
+  } catch (error: any) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        error?.response?.data?.message || 'Failed to create inventory item',
+      life: 3000,
+    });
+  }
+};
+
+onMounted(() => {
+  generateUUID();
+  // If we have an SSP ID prop, default to SSP destination
+  if (props.sspId) {
+    destination.value = 'ssp';
+    selectedSspId.value = props.sspId;
+  }
+});
+</script>

--- a/src/composables/axios/index.ts
+++ b/src/composables/axios/index.ts
@@ -6,11 +6,11 @@ import { useToast } from 'primevue/usetoast';
 import type {
   UseAxiosOptions,
   UseAxiosOptionsWithInitialData,
-} from '@vueuse/integrations/useAxios.mjs';
+} from '@vueuse/integrations/useAxios';
 import type { AxiosHeaders, AxiosRequestConfig } from 'axios';
 import type { DataResponse } from '@/stores/types.ts';
 import { shallowRef, toValue, watch, type Ref } from 'vue';
-import { useAxios } from '@vueuse/integrations/useAxios.mjs';
+import { useAxios } from '@vueuse/integrations/useAxios';
 import camelcaseKeys from 'camelcase-keys';
 import { default as _decamelizeKeys } from 'decamelize-keys';
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -103,6 +103,14 @@ const authenticatedRoutes = [
     },
   },
   {
+    path: 'inventory-plus',
+    name: 'inventory-plus:index',
+    component: () => import('../views/InventoryPlusView.vue'),
+    meta: {
+      requiresAuth: true,
+    },
+  },
+  {
     path: '/catalogs',
     name: 'catalog-list',
     // route level code-splitting

--- a/src/stores/evidence.ts
+++ b/src/stores/evidence.ts
@@ -70,7 +70,9 @@ export const useEvidenceStore = defineStore('evidence', () => {
 
   async function get(id: string): Promise<DataResponse<Evidence>> {
     const config = await configStore.getConfig();
-    const response = await fetch(`${config.API_URL}/api/evidence/${id}`);
+    const response = await fetch(`${config.API_URL}/api/evidence/${id}`, {
+      credentials: 'include',
+    });
     const responseJson = await response.json();
     return camelcaseKeys(responseJson, {
       deep: true,
@@ -81,6 +83,9 @@ export const useEvidenceStore = defineStore('evidence', () => {
     const config = await configStore.getConfig();
     const response = await fetch(
       `${config.API_URL}/api/evidence/for-control/${controlId}`,
+      {
+        credentials: 'include',
+      },
     );
     return (await response.json()) as ForControlResponse;
   }
@@ -89,6 +94,7 @@ export const useEvidenceStore = defineStore('evidence', () => {
     const config = await configStore.getConfig();
     const response = await fetch(`${config.API_URL}/api/evidence/search`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -110,6 +116,7 @@ export const useEvidenceStore = defineStore('evidence', () => {
     const config = await configStore.getConfig();
     const response = await fetch(`${config.API_URL}/api/evidence`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -134,6 +141,7 @@ export const useEvidenceStore = defineStore('evidence', () => {
       `${config.API_URL}/api/evidence/history/${uuid}`,
       {
         method: 'GET',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -159,6 +167,7 @@ export const useEvidenceStore = defineStore('evidence', () => {
         }),
       {
         method: 'POST',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -187,6 +196,7 @@ export const useEvidenceStore = defineStore('evidence', () => {
         }),
       {
         method: 'GET',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -206,6 +216,9 @@ export const useEvidenceStore = defineStore('evidence', () => {
     const config = await configStore.getConfig();
     const response = await fetch(
       `${config.API_URL}/api/evidence/compliance-by-control/${control.id}`,
+      {
+        credentials: 'include',
+      },
     );
     return (await response.json()) as DataResponse<ComplianceIntervalStatus[]>;
   }

--- a/src/views/InventoryPlusView.vue
+++ b/src/views/InventoryPlusView.vue
@@ -72,19 +72,6 @@
             class="w-full"
           />
         </div>
-
-        <!-- Status Filter -->
-        <div>
-          <label class="block text-sm font-medium mb-2">Status</label>
-          <Select
-            v-model="filters.status"
-            :options="statusOptions"
-            optionLabel="label"
-            optionValue="value"
-            placeholder="All statuses"
-            class="w-full"
-          />
-        </div>
       </div>
     </div>
 
@@ -372,7 +359,6 @@ const filters = reactive({
   includeAP: false,
   includeAR: false,
   itemType: null as string | null,
-  status: null as string | null,
 });
 
 // Filter options
@@ -389,15 +375,6 @@ const itemTypeOptions = [
   { label: 'Email Server', value: 'email-server' },
   { label: 'Directory Server', value: 'directory-server' },
   { label: 'Storage Array', value: 'storage-array' },
-];
-
-const statusOptions = [
-  { label: 'All statuses', value: null },
-  { label: 'Operational', value: 'operational' },
-  { label: 'Under Maintenance', value: 'under-maintenance' },
-  { label: 'Planned', value: 'planned' },
-  { label: 'Pending Approval', value: 'pending-approval' },
-  { label: 'Disposed', value: 'disposed' },
 ];
 
 // Build query parameters based on filters
@@ -425,10 +402,6 @@ const buildQueryParams = () => {
 
   if (filters.itemType) {
     params.append('item_type', filters.itemType);
-  }
-
-  if (filters.status) {
-    params.append('status', filters.status);
   }
 
   return params.toString();

--- a/src/views/InventoryPlusView.vue
+++ b/src/views/InventoryPlusView.vue
@@ -574,8 +574,7 @@ function attachInventoryItem(item: InventoryItemWithSource) {
   showInventoryItemAttachModal.value = true;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function attachToSSP(item: InventoryItemWithSource) {
+async function attachToSSP(_item: InventoryItemWithSource) {
   // This would add a non-SSP inventory item to the SSP
   // For now, show a message that this needs to be implemented
   // The item parameter will be used when this feature is implemented

--- a/src/views/InventoryPlusView.vue
+++ b/src/views/InventoryPlusView.vue
@@ -235,19 +235,19 @@
             </div>
 
             <!-- Implemented Components -->
-            <div v-if="item.implemented_components?.length" class="mt-3">
+            <div v-if="item.implementedComponents?.length" class="mt-3">
               <span
                 class="text-sm font-medium text-gray-700 dark:text-slate-300"
               >
                 Implemented Components:
               </span>
               <div
-                v-for="impl in item.implemented_components"
-                :key="impl.component_uuid || impl.componentUuid"
+                v-for="impl in item.implementedComponents"
+                :key="impl.componentUuid"
                 class="bg-white dark:bg-slate-900 p-3 rounded border border-gray-200 dark:border-slate-600 mt-2"
               >
                 <div class="font-medium text-sm font-mono">
-                  {{ impl.component_uuid || impl.componentUuid }}
+                  {{ impl.componentUuid }}
                 </div>
                 <div
                   v-if="impl.remarks"

--- a/src/views/InventoryPlusView.vue
+++ b/src/views/InventoryPlusView.vue
@@ -531,7 +531,7 @@ const editInventoryItem = (item: InventoryItemWithSource) => {
   showEditInventoryItemModal.value = true;
 };
 
-const handleInventoryItemCreated = async (newItem: InventoryItem) => {
+const handleInventoryItemCreated = async () => {
   showCreateInventoryItemModal.value = false;
   // Reload items to show the new one
   await loadInventoryItems();
@@ -543,7 +543,7 @@ const handleInventoryItemCreated = async (newItem: InventoryItem) => {
   });
 };
 
-const handleInventoryItemSaved = async (updatedItem: InventoryItem) => {
+const handleInventoryItemSaved = async () => {
   showEditInventoryItemModal.value = false;
   editingInventoryItem.value = null;
   // Reload items to show the updated one
@@ -556,7 +556,7 @@ const handleInventoryItemSaved = async (updatedItem: InventoryItem) => {
   });
 };
 
-const handleInventoryItemAttached = async (updatedItem: InventoryItem) => {
+const handleInventoryItemAttached = async () => {
   showInventoryItemAttachModal.value = false;
   editingInventoryItem.value = null;
   // Reload items to show the updated attachment
@@ -574,9 +574,11 @@ function attachInventoryItem(item: InventoryItemWithSource) {
   showInventoryItemAttachModal.value = true;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function attachToSSP(item: InventoryItemWithSource) {
   // This would add a non-SSP inventory item to the SSP
   // For now, show a message that this needs to be implemented
+  // The item parameter will be used when this feature is implemented
   toast.add({
     severity: 'info',
     summary: 'Feature Coming Soon',

--- a/src/views/InventoryPlusView.vue
+++ b/src/views/InventoryPlusView.vue
@@ -294,8 +294,8 @@
     <!-- Inventory Item Edit Modal -->
     <Dialog v-model:visible="showEditInventoryItemModal" modal>
       <SystemImplementationInventoryItemEditForm
-        v-if="system.securityPlan"
-        :ssp-id="sspId"
+        v-if="system.securityPlan && editingInventoryItem"
+        :ssp-id="editingInventoryItem.sourceId || sspId"
         :inventory-item="editingInventoryItem!"
         @cancel="showEditInventoryItemModal = false"
         @saved="handleInventoryItemSaved"
@@ -305,8 +305,8 @@
     <!-- Inventory Item Attach Modal -->
     <Dialog v-model:visible="showInventoryItemAttachModal" modal>
       <SystemImplementationInventoryItemAttachModal
-        v-if="system.securityPlan"
-        :ssp-id="sspId"
+        v-if="system.securityPlan && editingInventoryItem"
+        :ssp-id="editingInventoryItem.sourceId || sspId"
         :item="editingInventoryItem!"
         @cancel="showInventoryItemAttachModal = false"
         @saved="handleInventoryItemAttached"
@@ -588,11 +588,11 @@ async function attachToSSP(item: InventoryItemWithSource) {
 }
 
 const deleteInventoryItem = async (item: InventoryItemWithSource) => {
-  if (!sspId.value || item.sourceType !== 'ssp') {
+  if (item.sourceType !== 'ssp' || !item.sourceId) {
     toast.add({
       severity: 'error',
       summary: 'Error',
-      detail: 'Can only delete items attached to the current SSP.',
+      detail: 'Can only delete SSP inventory items.',
       life: 5000,
     });
     return;
@@ -600,7 +600,7 @@ const deleteInventoryItem = async (item: InventoryItemWithSource) => {
 
   try {
     await executeDelete(
-      `/api/oscal/system-security-plans/${sspId.value}/system-implementation/inventory-items/${item.uuid}`,
+      `/api/oscal/system-security-plans/${item.sourceId}/system-implementation/inventory-items/${item.uuid}`,
     );
     // Reload items after deletion
     await loadInventoryItems();

--- a/src/views/InventoryPlusView.vue
+++ b/src/views/InventoryPlusView.vue
@@ -96,7 +96,7 @@
             <strong>{{ inventoryItems?.length || 0 }}</strong> total items
           </span>
           <span v-if="sourceStats.ssp > 0">
-            <Badge value="SSP" severity="info" /> {{ sourceStats.ssp }}
+            <Badge value="SSP" severity="secondary" /> {{ sourceStats.ssp }}
           </span>
           <span v-if="sourceStats.evidence > 0">
             <Badge value="Evidence" severity="success" />
@@ -106,7 +106,7 @@
             <Badge value="POAM" severity="warning" /> {{ sourceStats.poam }}
           </span>
           <span v-if="sourceStats.ap > 0">
-            <Badge value="AP" severity="contrast" /> {{ sourceStats.ap }}
+            <Badge value="AP" severity="info" /> {{ sourceStats.ap }}
           </span>
           <span v-if="sourceStats.ar > 0">
             <Badge value="AR" severity="danger" /> {{ sourceStats.ar }}
@@ -531,20 +531,22 @@ const showInventoryItemAttachModal = ref(false);
 const { firstOfProps } = useProps();
 
 // Get severity color for source badge
+// Use different severities that have better distinction
+// PrimeVue severities: success (green), info (blue), warning (yellow/orange), danger (red), secondary (gray)
 const getSourceSeverity = (sourceType: string) => {
   switch (sourceType) {
     case 'ssp':
-      return 'info';
+      return 'secondary'; // Gray - different from info blue used for asset types
     case 'evidence':
-      return 'success';
+      return 'success'; // Green - good for discovered items
     case 'poam':
-      return 'warning';
+      return 'warning'; // Orange/Yellow - items needing action
     case 'assessment-plan':
     case 'ap':
-      return 'contrast';
+      return 'info'; // Blue - planned assessments
     case 'assessment-results':
     case 'ar':
-      return 'danger';
+      return 'danger'; // Red - findings that need attention
     default:
       return 'secondary';
   }

--- a/src/views/LeftSideNav.vue
+++ b/src/views/LeftSideNav.vue
@@ -54,14 +54,9 @@ const links = ref<Array<NavigationItem>>([
     abbr: 'RIS',
   },
   {
-    name: 'inventory:index',
+    name: 'inventory-plus:index',
     title: 'Inventory',
     abbr: 'INV',
-  },
-  {
-    name: 'inventory-plus:index',
-    title: 'Inventory Plus',
-    abbr: 'INV+',
   },
   {
     name: 'evidence:index',

--- a/src/views/LeftSideNav.vue
+++ b/src/views/LeftSideNav.vue
@@ -59,6 +59,11 @@ const links = ref<Array<NavigationItem>>([
     abbr: 'INV',
   },
   {
+    name: 'inventory-plus:index',
+    title: 'Inventory Plus',
+    abbr: 'INV+',
+  },
+  {
     name: 'evidence:index',
     title: 'Evidence',
     abbr: 'EV',


### PR DESCRIPTION
- Create new InventoryPlusView.vue that displays ALL inventory items from all sources
- Uses new /api/oscal/inventory endpoint to fetch items from SSPs, Evidence, POAMs
- Add filtering UI components:
  - Source selection (SSP, Evidence, POA&M checkboxes)
  - Item type dropdown (operating-system, database, web-server, etc.)
  - SSP attachment status filter
- Display source information for each inventory item with color-coded badges
- Show statistics bar with item counts per source
- Support for Create/Edit/Delete/Attach operations based on item source
- Add route and navigation link for Inventory Plus page
- Fix axios import path issue (.mjs extension removed)

This addresses the JIRA requirement to display all inventory items regardless of SSP attachment status, enabling visibility of inventory returned by agents during evidence collection.