### PR TITLE
BCH-1151: Fix Started column and Completed fallback in execution history

### DIFF
--- a/src/views/workflow-instances/WorkflowInstanceExecutionsView.vue
+++ b/src/views/workflow-instances/WorkflowInstanceExecutionsView.vue
@@ -72,7 +72,7 @@
             <td
               class="px-6 py-4 text-sm text-gray-500 dark:text-slate-400 whitespace-nowrap"
             >
-              {{ formatDate(execution.triggeredAt) }}
+              {{ execution.startedAt ? formatDate(execution.startedAt) : '-' }}
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
               <Badge :severity="getStatusSeverity(execution.status)">
@@ -91,7 +91,9 @@
               <span v-else-if="execution.cancelledAt" class="text-red-500">
                 Cancelled: {{ formatDate(execution.cancelledAt) }}
               </span>
-              <span v-else class="text-gray-400">-</span>
+              <span v-else class="text-gray-400">{{
+                execution.status.replace('_', ' ')
+              }}</span>
             </td>
             <td class="px-6 py-4 text-right">
               <RouterLinkButton

--- a/src/views/workflow-instances/WorkflowInstanceExecutionsView.vue
+++ b/src/views/workflow-instances/WorkflowInstanceExecutionsView.vue
@@ -76,7 +76,7 @@
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
               <Badge :severity="getStatusSeverity(execution.status)">
-                {{ execution.status.replace('_', ' ') }}
+                {{ execution.status.replace(/_/g, ' ') }}
               </Badge>
             </td>
             <td class="px-6 py-4 text-sm text-gray-500 dark:text-slate-400">
@@ -92,7 +92,7 @@
                 Cancelled: {{ formatDate(execution.cancelledAt) }}
               </span>
               <span v-else class="text-gray-400">{{
-                execution.status.replace('_', ' ')
+                execution.status.replace(/_/g, ' ')
               }}</span>
             </td>
             <td class="px-6 py-4 text-right">

--- a/src/views/workflow-instances/__tests__/WorkflowInstanceExecutionsView.spec.ts
+++ b/src/views/workflow-instances/__tests__/WorkflowInstanceExecutionsView.spec.ts
@@ -2,10 +2,18 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { reactive } from 'vue';
 import WorkflowInstanceExecutionsView from '../WorkflowInstanceExecutionsView.vue';
-import type { WorkflowExecution } from '@/types/workflows';
+import type { WorkflowExecution, WorkflowInstance } from '@/types/workflows';
 
 const mockStore = reactive({
-  instance: { id: 'instance-1', name: 'Test Instance' } as object | null,
+  instance: {
+    id: 'instance-1',
+    name: 'Test Instance',
+    workflowDefinitionId: 'def-1',
+    cadence: 'monthly',
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  } as WorkflowInstance | null,
   executions: [] as WorkflowExecution[],
   isActive: true,
   addExecutionLocally: vi.fn(),
@@ -59,7 +67,15 @@ describe('WorkflowInstanceExecutionsView', () => {
     vi.clearAllMocks();
     mockStore.executions = [];
     mockStore.isActive = true;
-    mockStore.instance = { id: 'instance-1', name: 'Test Instance' };
+    mockStore.instance = {
+      id: 'instance-1',
+      name: 'Test Instance',
+      workflowDefinitionId: 'def-1',
+      cadence: 'monthly',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
   });
 
   it('renders startedAt in the Started column, not triggeredAt', async () => {

--- a/src/views/workflow-instances/__tests__/WorkflowInstanceExecutionsView.spec.ts
+++ b/src/views/workflow-instances/__tests__/WorkflowInstanceExecutionsView.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { reactive } from 'vue';
+import WorkflowInstanceExecutionsView from '../WorkflowInstanceExecutionsView.vue';
+import type { WorkflowExecution } from '@/types/workflows';
+
+const mockStore = reactive({
+  instance: { id: 'instance-1', name: 'Test Instance' } as object | null,
+  executions: [] as WorkflowExecution[],
+  isActive: true,
+  addExecutionLocally: vi.fn(),
+});
+
+vi.mock('@/stores/workflows/instances', () => ({
+  useWorkflowInstanceStore: () => mockStore,
+}));
+
+vi.mock('@/composables/workflows', () => ({
+  useWorkflowExecutions: () => ({
+    startExecution: vi.fn(),
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+function createExecution(
+  overrides: Partial<WorkflowExecution> = {},
+): WorkflowExecution {
+  return {
+    id: 'exec-1',
+    workflowInstanceId: 'instance-1',
+    status: 'in_progress',
+    triggeredBy: 'manual',
+    triggeredAt: '2026-01-01T09:00:00.000Z',
+    createdAt: '2026-01-01T09:00:00.000Z',
+    updatedAt: '2026-01-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function mountComponent() {
+  return mount(WorkflowInstanceExecutionsView, {
+    global: {
+      stubs: {
+        PrimaryButton: { template: '<button><slot /></button>' },
+        SecondaryButton: { template: '<button><slot /></button>' },
+        RouterLinkButton: { template: '<a><slot /></a>' },
+        Badge: { template: '<span><slot /></span>' },
+        Dialog: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+}
+
+describe('WorkflowInstanceExecutionsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore.executions = [];
+    mockStore.isActive = true;
+    mockStore.instance = { id: 'instance-1', name: 'Test Instance' };
+  });
+
+  it('renders startedAt in the Started column, not triggeredAt', async () => {
+    mockStore.executions = [
+      createExecution({
+        triggeredAt: '2026-01-01T09:00:00.000Z',
+        startedAt: '2026-01-01T09:05:00.000Z',
+      }),
+    ];
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(1);
+
+    const startedCell = rows[0].findAll('td')[0];
+    const startedText = startedCell.text();
+
+    const triggeredDate = new Date('2026-01-01T09:00:00.000Z').toLocaleString();
+    const startedDate = new Date('2026-01-01T09:05:00.000Z').toLocaleString();
+
+    expect(startedText).toContain(startedDate);
+    expect(startedText).not.toContain(triggeredDate);
+  });
+
+  it('shows state-specific text in Completed column for in-progress executions', async () => {
+    mockStore.executions = [
+      createExecution({ status: 'in_progress', completedAt: undefined }),
+    ];
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const rows = wrapper.findAll('tbody tr');
+    const completedCell = rows[0].findAll('td')[3];
+
+    expect(completedCell.text()).not.toBe('-');
+    expect(completedCell.text().toLowerCase()).toContain('in progress');
+  });
+});


### PR DESCRIPTION
Started column was rendering triggeredAt instead of startedAt. Completed column showed a bare dash for in-progress/pending executions; now shows the status text (e.g. "in progress", "overdue") as a meaningful label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Started column now shows the actual start time (falls back to '-' when missing).
  * Status badges render underscores as spaces throughout (e.g., "in progress").
  * Completed column displays the execution status text when no completion or cancellation timestamp exists.

* **Tests**
  * Added tests validating started/completed display and status formatting in the workflow executions view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->