### PR TITLE
BCH-1149: Remove Estimated Duration from step definition and executio…

### DIFF
--- a/src/views/workflow-executions/partials/StepExecutionPanel.vue
+++ b/src/views/workflow-executions/partials/StepExecutionPanel.vue
@@ -46,14 +46,6 @@
               {{ stepDefinition?.responsibleRole || 'Not assigned' }}
             </div>
           </div>
-          <div>
-            <div class="text-xs text-gray-500 dark:text-slate-400">
-              Estimated Duration
-            </div>
-            <div class="text-sm font-medium text-gray-900 dark:text-slate-200">
-              {{ formatDuration(stepDefinition?.estimatedDurationMinutes) }}
-            </div>
-          </div>
         </div>
 
         <!-- Timestamps -->
@@ -586,14 +578,6 @@ function formatStatus(status: string): string {
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleString();
-}
-
-function formatDuration(minutes?: number): string {
-  if (!minutes) return 'Not specified';
-  if (minutes < 60) return `${minutes} minutes`;
-  const hours = Math.floor(minutes / 60);
-  const mins = minutes % 60;
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }
 
 async function handleStart() {

--- a/src/views/workflow-executions/partials/__tests__/StepExecutionPanel.spec.ts
+++ b/src/views/workflow-executions/partials/__tests__/StepExecutionPanel.spec.ts
@@ -164,6 +164,34 @@ describe('StepExecutionPanel reassignment', () => {
   });
 });
 
+// BCH-1149: estimatedDuration is not used operationally and should not be shown
+describe('StepExecutionPanel estimated duration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanTransition.mockResolvedValue(false);
+  });
+
+  it('does not render Estimated Duration metadata', async () => {
+    const wrapper = mountComponent(
+      createStep('pending', {
+        workflowStepDefinition: {
+          id: 'def-1',
+          workflowDefinitionId: 'wf-1',
+          name: 'Step A',
+          order: 1,
+          evidenceRequired: [],
+          estimatedDurationMinutes: 45,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    );
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('Estimated Duration');
+  });
+});
+
 describe('StepExecutionPanel overdue behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/views/workflows/partials/StepDefinitionForm.vue
+++ b/src/views/workflows/partials/StepDefinitionForm.vue
@@ -54,19 +54,6 @@
       </small>
     </div>
 
-    <!-- Estimated Duration -->
-    <div>
-      <Label for="step-duration">Estimated Duration (minutes)</Label>
-      <input
-        id="step-duration"
-        v-model.number="form.estimatedDurationMinutes"
-        type="number"
-        min="0"
-        placeholder="30"
-        class="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-200 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-      />
-    </div>
-
     <!-- Grace Period -->
     <div>
       <Label for="step-grace-period">Grace Period (Days)</Label>
@@ -251,7 +238,6 @@ type StepFormState = {
   responsibleRole: string;
   evidenceRequiredEnabled: boolean;
   evidenceItems: EvidenceItem[];
-  estimatedDurationMinutes: number;
   gracePeriodDays: number;
   order: number;
   dependsOn: string[];
@@ -271,7 +257,6 @@ const form = reactive<StepFormState>({
   responsibleRole: '',
   evidenceRequiredEnabled: true,
   evidenceItems: [...defaultEvidenceItems],
-  estimatedDurationMinutes: 30,
   gracePeriodDays: effectiveDefaultGracePeriodDays,
   order: 1,
   dependsOn: [],
@@ -314,7 +299,6 @@ function initForm() {
             required: req.required,
           }))
         : [...defaultEvidenceItems];
-    form.estimatedDurationMinutes = props.step.estimatedDurationMinutes || 30;
     form.gracePeriodDays =
       props.step.gracePeriodDays ?? effectiveDefaultGracePeriodDays;
     gracePeriodDaysInput.value =
@@ -330,7 +314,6 @@ function initForm() {
     form.responsibleRole = '';
     form.evidenceRequiredEnabled = true;
     form.evidenceItems = [...defaultEvidenceItems];
-    form.estimatedDurationMinutes = 30;
     form.gracePeriodDays = effectiveDefaultGracePeriodDays;
     gracePeriodDaysInput.value = toGracePeriodInputValue(
       effectiveDefaultGracePeriodDays,
@@ -398,7 +381,6 @@ async function handleSubmit() {
         description: form.description || undefined,
         responsibleRole: form.responsibleRole || undefined,
         evidenceRequired: buildEvidencePayload(),
-        estimatedDurationMinutes: form.estimatedDurationMinutes || undefined,
         gracePeriodDays: form.gracePeriodDays,
         order: form.order,
         dependsOn: form.dependsOn,
@@ -415,7 +397,6 @@ async function handleSubmit() {
         description: form.description || undefined,
         responsibleRole: form.responsibleRole || undefined,
         evidenceRequired: buildEvidencePayload(),
-        estimatedDurationMinutes: form.estimatedDurationMinutes || undefined,
         gracePeriodDays: form.gracePeriodDays,
         order: form.order,
         dependsOn: form.dependsOn,

--- a/src/views/workflows/partials/__tests__/StepDefinitionForm.spec.ts
+++ b/src/views/workflows/partials/__tests__/StepDefinitionForm.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import StepDefinitionForm from '../StepDefinitionForm.vue';
+
+vi.mock('@/composables/workflows', () => ({
+  useWorkflowStepDefinitions: () => ({
+    createStep: vi.fn(),
+    updateStep: vi.fn(),
+  }),
+}));
+
+vi.mock('@/utils/workflows', () => ({
+  DEFAULT_GRACE_PERIOD_DAYS: 7,
+  parseGracePeriodInput: vi.fn().mockReturnValue({ value: 7 }),
+  parseEvidenceRequired: vi.fn().mockReturnValue([]),
+  toGracePeriodInputValue: vi.fn().mockReturnValue('7'),
+}));
+
+function mountForm() {
+  return mount(StepDefinitionForm, {
+    props: {
+      workflowDefinitionId: 'wf-1',
+      availableSteps: [],
+    },
+    global: {
+      stubs: {
+        Label: { template: '<label><slot /></label>' },
+        InputText: {
+          props: ['modelValue'],
+          template: '<input :value="modelValue" />',
+        },
+        Textarea: {
+          props: ['modelValue'],
+          template: '<textarea :value="modelValue" />',
+        },
+        Select: { template: '<div />' },
+        MultiSelect: { template: '<div />' },
+        Message: { template: '<div><slot /></div>' },
+        PrimaryButton: { template: '<button type="submit"><slot /></button>' },
+        SecondaryButton: { template: '<button><slot /></button>' },
+      },
+    },
+  });
+}
+
+// BCH-1149: estimatedDuration is not used operationally and should not appear in the form
+describe('StepDefinitionForm estimated duration', () => {
+  it('does not render an Estimated Duration input field', () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.text()).not.toContain('Estimated Duration');
+    expect(wrapper.find('#step-duration').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
…n UI

Field is not used operationally. Removes the form input, the execution panel display, and the dead formatDuration helper and form state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed "Estimated Duration" field from workflow step execution display and step definition form.

* **Tests**
  * Added test coverage to verify the field is not rendered in step execution and definition interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->