### PR TITLE
Fix/bch 1155

### DIFF
--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -198,6 +198,7 @@ export interface WorkflowExecution {
   overdueAt?: string;
   failureReason?: string;
   parentExecutionId?: string;
+  executionStreamUuid?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/views/evidence/ViewView.vue
+++ b/src/views/evidence/ViewView.vue
@@ -18,6 +18,12 @@
       </div>
 
       <div class="flex flex-wrap items-center gap-2">
+        <RouterLinkButton
+          v-if="workflowExecutionRoute"
+          :to="workflowExecutionRoute"
+        >
+          Back to Execution
+        </RouterLinkButton>
         <SecondaryButton v-if="evidence" @click="directToUpdate()">
           Update Evidence
         </SecondaryButton>
@@ -752,6 +758,7 @@ import type { Activity, BackMatterResource, Link, Property } from '@/oscal';
 import SecondaryButton from '@/volt/SecondaryButton.vue';
 import Dialog from '@/volt/Dialog.vue';
 import Message from '@/volt/Message.vue';
+import RouterLinkButton from '@/components/RouterLinkButton.vue';
 import {
   BIconDownload,
   BIconLockFill,
@@ -808,6 +815,20 @@ const {
   null,
   { method: 'POST' },
   { immediate: false },
+);
+
+const workflowExecutionId = computed(
+  () =>
+    evidence.value?.labels.find((l) => l.name === 'workflow.execution.id')
+      ?.value,
+);
+const workflowExecutionRoute = computed(() =>
+  workflowExecutionId.value
+    ? {
+        name: 'workflow-execution-view',
+        params: { id: workflowExecutionId.value },
+      }
+    : null,
 );
 
 const metadataProps = computed<Property[]>(() => evidence.value?.props ?? []);

--- a/src/views/evidence/__tests__/ViewView.spec.ts
+++ b/src/views/evidence/__tests__/ViewView.spec.ts
@@ -457,6 +457,10 @@ function mountView() {
           props: ['to'],
           template: '<a :data-to="JSON.stringify(to)"><slot /></a>',
         },
+        RouterLinkButton: {
+          props: ['to'],
+          template: '<a :data-to="JSON.stringify(to)"><slot /></a>',
+        },
         BackMatterDisplay: {
           props: ['resource'],
           template: '<div>BackMatterDisplay {{ resource.title }}</div>',
@@ -827,5 +831,65 @@ describe('Evidence ViewView', () => {
 
     expect(wrapper.text()).toContain('Error loading evidence');
     expect(wrapper.text()).not.toContain('Repository attestation evidence');
+  });
+});
+
+describe('Evidence ViewView workflow execution back-link', () => {
+  // BCH-1155: evidence records from workflow executions must provide a link back to the execution view
+  beforeEach(() => {
+    refs.nullGetCallIndex = 0;
+    refs.verification.value = null;
+    refs.loading.value = false;
+    refs.error.value = null;
+    refs.signatureError.value = null;
+    refs.verifyError.value = null;
+    refs.history.value = structuredClone(historyItems);
+    refs.compliance.value = structuredClone(complianceHistory);
+    refs.heartbeat.value = structuredClone(heartbeatHistory);
+    refs.route.params.id = 'evidence-1';
+    refs.route.query = {};
+  });
+
+  it('shows Back to Execution link when evidence has workflow.execution.id label', async () => {
+    const workflowEvidence = {
+      ...structuredClone(baseEvidence),
+      labels: [{ name: 'workflow.execution.id', value: 'exec-abc-123' }],
+    };
+    refs.evidenceResponse = workflowEvidence;
+    refs.evidence.value = workflowEvidence;
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Back to Execution');
+  });
+
+  it('links to the workflow execution view using the execution id from labels', async () => {
+    const workflowEvidence = {
+      ...structuredClone(baseEvidence),
+      labels: [{ name: 'workflow.execution.id', value: 'exec-abc-123' }],
+    };
+    refs.evidenceResponse = workflowEvidence;
+    refs.evidence.value = workflowEvidence;
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    const link = wrapper.find('a[data-to*="exec-abc-123"]');
+    expect(link.exists()).toBe(true);
+  });
+
+  it('does not show Back to Execution link when evidence has no workflow.execution.id label', async () => {
+    const plainEvidence = {
+      ...structuredClone(baseEvidence),
+      labels: [{ name: 'env', value: 'prod' }],
+    };
+    refs.evidenceResponse = plainEvidence;
+    refs.evidence.value = plainEvidence;
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('Back to Execution');
   });
 });

--- a/src/views/evidence/__tests__/ViewView.spec.ts
+++ b/src/views/evidence/__tests__/ViewView.spec.ts
@@ -877,6 +877,11 @@ describe('Evidence ViewView workflow execution back-link', () => {
 
     const link = wrapper.find('a[data-to*="exec-abc-123"]');
     expect(link.exists()).toBe(true);
+    const to = JSON.parse(link.attributes('data-to') ?? '{}');
+    expect(to).toMatchObject({
+      name: 'workflow-execution-view',
+      params: { id: 'exec-abc-123' },
+    });
   });
 
   it('does not show Back to Execution link when evidence has no workflow.execution.id label', async () => {

--- a/src/views/workflow-executions/WorkflowExecutionView.vue
+++ b/src/views/workflow-executions/WorkflowExecutionView.vue
@@ -81,6 +81,19 @@
         >
           Retry Execution
         </SecondaryButton>
+        <RouterLinkButton
+          v-if="
+            (execution.status === 'completed' ||
+              execution.status === 'failed') &&
+            execution.executionStreamUuid
+          "
+          :to="{
+            name: 'evidence:history',
+            params: { uuid: execution.executionStreamUuid },
+          }"
+        >
+          View Evidence Stream
+        </RouterLinkButton>
       </div>
 
       <!-- Execution Metrics -->

--- a/src/views/workflow-executions/__tests__/WorkflowExecutionView.spec.ts
+++ b/src/views/workflow-executions/__tests__/WorkflowExecutionView.spec.ts
@@ -103,6 +103,15 @@ describe('WorkflowExecutionView evidence stream link', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('View Evidence Stream');
+    const link = wrapper.find(
+      'a[href*="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]',
+    );
+    expect(link.exists()).toBe(true);
+    const to = JSON.parse(link.attributes('href') ?? '{}');
+    expect(to).toMatchObject({
+      name: 'evidence:history',
+      params: { uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+    });
   });
 
   // BCH-1155: failed executions must also expose a link to the evidence stream
@@ -116,6 +125,15 @@ describe('WorkflowExecutionView evidence stream link', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('View Evidence Stream');
+    const link = wrapper.find(
+      'a[href*="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]',
+    );
+    expect(link.exists()).toBe(true);
+    const to = JSON.parse(link.attributes('href') ?? '{}');
+    expect(to).toMatchObject({
+      name: 'evidence:history',
+      params: { uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+    });
   });
 
   // BCH-1155: in-progress executions have no terminal evidence yet — no link expected

--- a/src/views/workflow-executions/__tests__/WorkflowExecutionView.spec.ts
+++ b/src/views/workflow-executions/__tests__/WorkflowExecutionView.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+import WorkflowExecutionView from '../WorkflowExecutionView.vue';
+import type { WorkflowExecution } from '@/types/workflows';
+
+const mockGetExecution = vi.fn();
+const mockGetExecutionStatus = vi.fn();
+const mockGetExecutionMetrics = vi.fn();
+const mockCancelExecution = vi.fn();
+const mockRetryExecution = vi.fn();
+const mockListStepExecutions = vi.fn();
+
+const execution = ref<WorkflowExecution | null>(null);
+const executionStatus = ref(null);
+const executionMetrics = ref(null);
+const stepExecutions = ref([]);
+
+vi.mock('@/composables/workflows', () => ({
+  useWorkflowExecutions: () => ({
+    execution,
+    executionStatus,
+    executionMetrics,
+    getExecution: mockGetExecution,
+    getExecutionStatus: mockGetExecutionStatus,
+    getExecutionMetrics: mockGetExecutionMetrics,
+    cancelExecution: mockCancelExecution,
+    retryExecution: mockRetryExecution,
+    executionStatusLoaded: ref(true),
+    executionMetricsLoaded: ref(true),
+  }),
+  useStepExecutions: () => ({
+    stepExecutions,
+    listStepExecutions: mockListStepExecutions,
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: 'exec-1' } }),
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}));
+
+function createExecution(
+  status: WorkflowExecution['status'],
+  overrides: Partial<WorkflowExecution> = {},
+): WorkflowExecution {
+  return {
+    id: 'exec-1',
+    workflowInstanceId: 'inst-1',
+    status,
+    triggeredBy: 'manual',
+    triggeredAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function mountComponent() {
+  return mount(WorkflowExecutionView, {
+    global: {
+      stubs: {
+        PageHeader: { template: '<div><slot /></div>' },
+        PageSubHeader: { template: '<div><slot /></div>' },
+        Badge: { template: '<span><slot /></span>' },
+        Message: { template: '<div><slot /></div>' },
+        SecondaryButton: { template: '<button><slot /></button>' },
+        RouterLinkButton: {
+          props: ['to'],
+          template: '<a :href="JSON.stringify(to)"><slot /></a>',
+        },
+        ExecutionMetrics: { template: '<div></div>' },
+        ExecutionDAGView: { template: '<div></div>' },
+        StepExecutionList: { template: '<div></div>' },
+        StepExecutionPanel: { template: '<div></div>' },
+      },
+    },
+  });
+}
+
+describe('WorkflowExecutionView evidence stream link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    execution.value = null;
+    executionStatus.value = null;
+    executionMetrics.value = null;
+    stepExecutions.value = [];
+    mockGetExecution.mockResolvedValue(undefined);
+    mockGetExecutionStatus.mockResolvedValue(undefined);
+    mockGetExecutionMetrics.mockResolvedValue(undefined);
+    mockListStepExecutions.mockResolvedValue(undefined);
+  });
+
+  // BCH-1155: completed executions must expose a navigable link to the evidence stream
+  it('shows evidence stream link when execution is completed and has executionStreamUuid', async () => {
+    execution.value = createExecution('completed', {
+      executionStreamUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      completedAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('View Evidence Stream');
+  });
+
+  // BCH-1155: failed executions must also expose a link to the evidence stream
+  it('shows evidence stream link when execution is failed and has executionStreamUuid', async () => {
+    execution.value = createExecution('failed', {
+      executionStreamUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      failureReason: 'some failure',
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('View Evidence Stream');
+  });
+
+  // BCH-1155: in-progress executions have no terminal evidence yet — no link expected
+  it('does not show evidence stream link for in_progress execution', async () => {
+    execution.value = createExecution('in_progress', {
+      executionStreamUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('View Evidence Stream');
+  });
+
+  // BCH-1155: no link when UUID is absent even if status is terminal
+  it('does not show evidence stream link when executionStreamUuid is absent', async () => {
+    execution.value = createExecution('completed', {
+      completedAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain('View Evidence Stream');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a conditional "Back to Execution" link on evidence pages to return to the originating workflow execution when available.
  * Adds a conditional "View Evidence Stream" link on workflow execution pages for completed or failed executions when an evidence stream is present.

* **Tests**
  * Added tests covering the new conditional navigation behavior and link targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->