### PR TITLE
BCH-1154: Remove #<order> prefix from step card headers in workflow d…

### DIFF
--- a/src/views/workflows/WorkflowDefinitionStepsView.vue
+++ b/src/views/workflows/WorkflowDefinitionStepsView.vue
@@ -40,9 +40,6 @@
         <div class="flex justify-between items-start">
           <div class="flex-1">
             <div class="flex items-center gap-2">
-              <span class="text-sm text-gray-400 dark:text-slate-500">
-                #{{ step.order }}
-              </span>
               <h4 class="font-medium text-gray-900 dark:text-slate-200">
                 {{ step.name }}
               </h4>

--- a/src/views/workflows/__tests__/WorkflowDefinitionStepsView.spec.ts
+++ b/src/views/workflows/__tests__/WorkflowDefinitionStepsView.spec.ts
@@ -57,8 +57,9 @@ describe('WorkflowDefinitionStepsView step order marker', () => {
   it('does not render the #<order> prefix in step card headers', () => {
     const wrapper = mountComponent();
 
-    // The step name should appear without the order marker
-    expect(wrapper.text()).toContain('Review Access');
-    expect(wrapper.text()).not.toContain('#3');
+    // The step header should contain the name and no order marker
+    const header = wrapper.find('h4');
+    expect(header.text()).toContain('Review Access');
+    expect(header.text()).not.toContain('#3');
   });
 });

--- a/src/views/workflows/__tests__/WorkflowDefinitionStepsView.spec.ts
+++ b/src/views/workflows/__tests__/WorkflowDefinitionStepsView.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import WorkflowDefinitionStepsView from '../WorkflowDefinitionStepsView.vue';
+import type { StepDefinition, WorkflowDefinition } from '@/types/workflows';
+
+vi.mock('@/stores/workflows/definitions', () => ({
+  useWorkflowDefinitionStore: () => ({
+    definition: {
+      id: 'def-1',
+      name: 'Test Workflow',
+      gracePeriodDays: 7,
+    } as WorkflowDefinition,
+    steps: [
+      {
+        id: 'step-1',
+        workflowDefinitionId: 'def-1',
+        name: 'Review Access',
+        order: 3,
+        evidenceRequired: [],
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ] as StepDefinition[],
+    addStepLocally: vi.fn(),
+    updateStepLocally: vi.fn(),
+    removeStepLocally: vi.fn(),
+  }),
+}));
+
+vi.mock('@/composables/workflows', () => ({
+  useWorkflowStepDefinitions: () => ({
+    deleteStep: vi.fn(),
+  }),
+}));
+
+vi.mock('@/utils/workflows', () => ({
+  hasEvidenceRequirement: () => false,
+}));
+
+function mountComponent() {
+  return mount(WorkflowDefinitionStepsView, {
+    global: {
+      stubs: {
+        PrimaryButton: { template: '<button><slot /></button>' },
+        SecondaryButton: { template: '<button><slot /></button>' },
+        Badge: { template: '<span><slot /></span>' },
+        Drawer: { template: '<div><slot /></div>' },
+        StepDAGVisualization: { template: '<div></div>' },
+        StepDefinitionForm: { template: '<div></div>' },
+      },
+    },
+  });
+}
+
+describe('WorkflowDefinitionStepsView step order marker', () => {
+  // BCH-1154: step cards prepend #<order> before the name, which is noisy and not useful
+  it('does not render the #<order> prefix in step card headers', () => {
+    const wrapper = mountComponent();
+
+    // The step name should appear without the order marker
+    expect(wrapper.text()).toContain('Review Access');
+    expect(wrapper.text()).not.toContain('#3');
+  });
+});


### PR DESCRIPTION
…efinition steps view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the numeric order indicator previously displayed alongside workflow step names in the steps list; step headers now show only the step name for a cleaner, less cluttered interface.

* **Tests**
  * Added a unit test to verify workflow step card headers render the step name and do not include the order-number prefix, ensuring the UI remains consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->