### PR TITLE
BCH-1152: Show API validation error message in step create/update toast

### DIFF
--- a/src/composables/workflows/useWorkflowStepDefinitions.ts
+++ b/src/composables/workflows/useWorkflowStepDefinitions.ts
@@ -190,13 +190,15 @@ export function useWorkflowStepDefinitions() {
             onSuccess?.();
             resolve();
           } catch (error) {
+            const detail =
+              (isAxiosError(error) && error.response?.data?.errors?.body) ||
+              (error instanceof Error
+                ? error.message
+                : 'Failed to delete step definition');
             toast.add({
               severity: 'error',
               summary: 'Error Deleting Step',
-              detail:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to delete step definition',
+              detail,
               life: 3000,
             });
             reject(error);

--- a/src/composables/workflows/useWorkflowStepDefinitions.ts
+++ b/src/composables/workflows/useWorkflowStepDefinitions.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
 import { useToast } from 'primevue/usetoast';
 import { useConfirm } from 'primevue/useconfirm';
@@ -116,13 +117,15 @@ export function useWorkflowStepDefinitions() {
       }
       return createdStep.value;
     } catch (error) {
+      const detail =
+        (isAxiosError(error) && error.response?.data?.errors?.body) ||
+        (error instanceof Error
+          ? error.message
+          : 'Failed to create step definition');
       toast.add({
         severity: 'error',
         summary: 'Error Creating Step',
-        detail:
-          error instanceof Error
-            ? error.message
-            : 'Failed to create step definition',
+        detail,
         life: 3000,
       });
       throw error;
@@ -150,13 +153,15 @@ export function useWorkflowStepDefinitions() {
       }
       return updatedStep.value;
     } catch (error) {
+      const detail =
+        (isAxiosError(error) && error.response?.data?.errors?.body) ||
+        (error instanceof Error
+          ? error.message
+          : 'Failed to update step definition');
       toast.add({
         severity: 'error',
         summary: 'Error Updating Step',
-        detail:
-          error instanceof Error
-            ? error.message
-            : 'Failed to update step definition',
+        detail,
         life: 3000,
       });
       throw error;

--- a/src/composables/workflows/useWorkflowStepDefinitions.ts
+++ b/src/composables/workflows/useWorkflowStepDefinitions.ts
@@ -1,5 +1,5 @@
-import { isAxiosError } from 'axios';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
+import { getErrorDetail } from '@/utils/httpErrors';
 import { useToast } from 'primevue/usetoast';
 import { useConfirm } from 'primevue/useconfirm';
 import type {
@@ -117,15 +117,10 @@ export function useWorkflowStepDefinitions() {
       }
       return createdStep.value;
     } catch (error) {
-      const detail =
-        (isAxiosError(error) && error.response?.data?.errors?.body) ||
-        (error instanceof Error
-          ? error.message
-          : 'Failed to create step definition');
       toast.add({
         severity: 'error',
         summary: 'Error Creating Step',
-        detail,
+        detail: await getErrorDetail(error, 'Failed to create step definition'),
         life: 3000,
       });
       throw error;
@@ -153,15 +148,10 @@ export function useWorkflowStepDefinitions() {
       }
       return updatedStep.value;
     } catch (error) {
-      const detail =
-        (isAxiosError(error) && error.response?.data?.errors?.body) ||
-        (error instanceof Error
-          ? error.message
-          : 'Failed to update step definition');
       toast.add({
         severity: 'error',
         summary: 'Error Updating Step',
-        detail,
+        detail: await getErrorDetail(error, 'Failed to update step definition'),
         life: 3000,
       });
       throw error;
@@ -190,15 +180,13 @@ export function useWorkflowStepDefinitions() {
             onSuccess?.();
             resolve();
           } catch (error) {
-            const detail =
-              (isAxiosError(error) && error.response?.data?.errors?.body) ||
-              (error instanceof Error
-                ? error.message
-                : 'Failed to delete step definition');
             toast.add({
               severity: 'error',
               summary: 'Error Deleting Step',
-              detail,
+              detail: await getErrorDetail(
+                error,
+                'Failed to delete step definition',
+              ),
               life: 3000,
             });
             reject(error);

--- a/src/utils/httpErrors.spec.ts
+++ b/src/utils/httpErrors.spec.ts
@@ -2,6 +2,77 @@ import { describe, it, expect } from 'vitest';
 import { getErrorDetail } from './httpErrors';
 
 describe('getErrorDetail', () => {
+  describe('Response errors', () => {
+    it('returns errors.body when present', async () => {
+      const response = new Response(
+        JSON.stringify({ errors: { body: 'validation failed' } }),
+        { status: 400, statusText: 'Bad Request' },
+      );
+      expect(await getErrorDetail(response, 'fallback')).toBe(
+        'validation failed',
+      );
+    });
+
+    it('preserves empty string errors.body instead of falling back', async () => {
+      const response = new Response(JSON.stringify({ errors: { body: '' } }), {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+      expect(await getErrorDetail(response, 'fallback')).toBe('');
+    });
+
+    it('returns message when errors.body is absent', async () => {
+      const response = new Response(
+        JSON.stringify({ message: 'something went wrong' }),
+        { status: 400, statusText: 'Bad Request' },
+      );
+      expect(await getErrorDetail(response, 'fallback')).toBe(
+        'something went wrong',
+      );
+    });
+
+    it('returns error field when message is absent', async () => {
+      const response = new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+      expect(await getErrorDetail(response, 'fallback')).toBe('unauthorized');
+    });
+
+    it('returns detail field when message and error are absent', async () => {
+      const response = new Response(JSON.stringify({ detail: 'not found' }), {
+        status: 404,
+        statusText: 'Not Found',
+      });
+      expect(await getErrorDetail(response, 'fallback')).toBe('not found');
+    });
+
+    it('falls back to statusText when JSON is unparseable', async () => {
+      const response = new Response('not-json', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      expect(await getErrorDetail(response, 'fallback')).toBe(
+        'Internal Server Error',
+      );
+    });
+
+    it('falls back to statusText when JSON body is null', async () => {
+      const response = new Response('null', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      expect(await getErrorDetail(response, 'fallback')).toBe(
+        'Internal Server Error',
+      );
+    });
+
+    it('falls back to fallback when statusText is also empty', async () => {
+      const response = new Response('null', { status: 500, statusText: '' });
+      expect(await getErrorDetail(response, 'fallback')).toBe('fallback');
+    });
+  });
+
   describe('Axios errors', () => {
     it('returns errors.body when present', async () => {
       const error = {

--- a/src/utils/httpErrors.spec.ts
+++ b/src/utils/httpErrors.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorDetail } from './httpErrors';
+
+describe('getErrorDetail', () => {
+  describe('Axios errors', () => {
+    it('returns errors.body when present', async () => {
+      const error = {
+        response: { data: { errors: { body: 'validation failed' } } },
+        message: 'Request failed',
+      };
+      expect(await getErrorDetail(error, 'fallback')).toBe('validation failed');
+    });
+
+    it('preserves empty string errors.body instead of falling back', async () => {
+      const error = {
+        response: { data: { errors: { body: '' } } },
+        message: 'Request failed',
+      };
+      expect(await getErrorDetail(error, 'fallback')).toBe('');
+    });
+
+    it('falls back to message when errors.body is undefined', async () => {
+      const error = {
+        response: { data: { errors: {} } },
+        message: 'Request failed',
+      };
+      expect(await getErrorDetail(error, 'fallback')).toBe('Request failed');
+    });
+
+    it('falls back to message when no response data', async () => {
+      const error = { response: null, message: 'Network error' };
+      expect(await getErrorDetail(error, 'fallback')).toBe('Network error');
+    });
+
+    it('falls back to fallback message when all else is empty', async () => {
+      const error = { response: null, message: '' };
+      expect(await getErrorDetail(error, 'fallback')).toBe('fallback');
+    });
+  });
+});

--- a/src/utils/httpErrors.ts
+++ b/src/utils/httpErrors.ts
@@ -43,8 +43,7 @@ export async function getErrorDetail(
 
   const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
   return (
-    errorResponse.response?.data?.errors?.body ||
-    errorResponse.message ||
-    fallbackMessage
+    errorResponse.response?.data?.errors?.body ??
+    (errorResponse.message || fallbackMessage)
   );
 }

--- a/src/utils/httpErrors.ts
+++ b/src/utils/httpErrors.ts
@@ -26,7 +26,7 @@ export async function getErrorDetail(
       }
 
       if ('errors' in errorData) {
-        return errorData.errors?.body || fallbackMessage;
+        return errorData.errors?.body ?? fallbackMessage;
       }
 
       return (

--- a/src/utils/workflows.ts
+++ b/src/utils/workflows.ts
@@ -1,6 +1,7 @@
 import type { EvidenceRequirement, EvidenceType } from '@/types/workflows';
 
 export const DEFAULT_GRACE_PERIOD_DAYS = 7;
+export const DEFAULT_STEP_GRACE_PERIOD_DAYS = 1;
 
 export function toGracePeriodInputValue(
   gracePeriodDays?: number | null,

--- a/src/views/workflows/WorkflowDefinitionStepsView.vue
+++ b/src/views/workflows/WorkflowDefinitionStepsView.vue
@@ -108,7 +108,6 @@
       <StepDefinitionForm
         :step="editingStep ?? undefined"
         :workflow-definition-id="store.definition.id"
-        :default-grace-period-days="store.definition.gracePeriodDays"
         :available-steps="store.steps"
         @saved="handleStepSaved"
         @cancel="closeForm"

--- a/src/views/workflows/partials/StepDefinitionForm.vue
+++ b/src/views/workflows/partials/StepDefinitionForm.vue
@@ -197,7 +197,7 @@ import type {
   EvidenceType,
 } from '@/types/workflows';
 import {
-  DEFAULT_GRACE_PERIOD_DAYS,
+  DEFAULT_STEP_GRACE_PERIOD_DAYS,
   parseGracePeriodInput,
   parseEvidenceRequired,
   toGracePeriodInputValue,
@@ -248,7 +248,7 @@ const defaultEvidenceItems: EvidenceItem[] = [
 ];
 // Step-level default comes from the parent workflow model when provided.
 const effectiveDefaultGracePeriodDays =
-  props.defaultGracePeriodDays ?? DEFAULT_GRACE_PERIOD_DAYS;
+  props.defaultGracePeriodDays ?? DEFAULT_STEP_GRACE_PERIOD_DAYS;
 
 const form = reactive<StepFormState>({
   workflowDefinitionId: props.workflowDefinitionId,

--- a/src/views/workflows/partials/__tests__/StepDefinitionForm.spec.ts
+++ b/src/views/workflows/partials/__tests__/StepDefinitionForm.spec.ts
@@ -11,9 +11,10 @@ vi.mock('@/composables/workflows', () => ({
 
 vi.mock('@/utils/workflows', () => ({
   DEFAULT_GRACE_PERIOD_DAYS: 7,
-  parseGracePeriodInput: vi.fn().mockReturnValue({ value: 7 }),
+  DEFAULT_STEP_GRACE_PERIOD_DAYS: 1,
+  parseGracePeriodInput: vi.fn().mockReturnValue({ value: 1 }),
   parseEvidenceRequired: vi.fn().mockReturnValue([]),
-  toGracePeriodInputValue: vi.fn().mockReturnValue('7'),
+  toGracePeriodInputValue: vi.fn().mockReturnValue('1'),
 }));
 
 function mountForm() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error toasts for create/update/delete workflows: details now prefer server-provided error text and otherwise fall back to standard messages; summaries, severity, and display duration unchanged.
* **Chores**
  * Workflow step form now uses a 1-day default grace period when no value is provided.
* **Tests**
  * Added unit tests covering error-detail selection for various error shapes and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->