### PR TITLE
Fix/bch 1150

### DIFF
--- a/src/composables/__tests__/usePoamItems.spec.ts
+++ b/src/composables/__tests__/usePoamItems.spec.ts
@@ -389,9 +389,7 @@ describe('usePoamItems', () => {
 
     it('accepts an empty payload (all fields optional)', async () => {
       const { promoteRiskToPoam } = usePromoteRiskToPoam();
-      await expect(
-        promoteRiskToPoam('ssp-123', 'risk-abc', {}),
-      ).resolves.not.toThrow();
+      await promoteRiskToPoam('ssp-123', 'risk-abc', {});
     });
   });
 

--- a/src/composables/__tests__/usePoamItems.spec.ts
+++ b/src/composables/__tests__/usePoamItems.spec.ts
@@ -389,7 +389,9 @@ describe('usePoamItems', () => {
 
     it('accepts an empty payload (all fields optional)', async () => {
       const { promoteRiskToPoam } = usePromoteRiskToPoam();
-      await promoteRiskToPoam('ssp-123', 'risk-abc', {});
+      await expect(
+        promoteRiskToPoam('ssp-123', 'risk-abc', {}),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -484,7 +484,7 @@ describe('useMyAssignments', () => {
       const { fetchMyAssignments } = useMyAssignments();
       await expect(
         fetchMyAssignments({ dueBefore: 'not-a-date', dueAfter: 'also-bad' }),
-      ).resolves.not.toThrow();
+      ).resolves.toBeDefined();
 
       const calledUrl = mockExecute.mock.calls[0][0] as string;
       expect(calledUrl).not.toContain('due_before');

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -469,6 +469,28 @@ describe('useMyAssignments', () => {
   });
 
   describe('edge cases', () => {
+    // new Date('not-a-date').toISOString() throws RangeError; invalid strings must
+    // be silently dropped so the API call still proceeds without the bad param.
+    it('silently omits due date params when the date string is invalid', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await expect(
+        fetchMyAssignments({ dueBefore: 'not-a-date', dueAfter: 'also-bad' }),
+      ).resolves.not.toThrow();
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain('due_before');
+      expect(calledUrl).not.toContain('due_after');
+    });
+
     it('handles empty results', async () => {
       const mockResponse: MyAssignmentsResponse = {
         data: [],

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -104,6 +104,86 @@ describe('useMyAssignments', () => {
       );
     });
 
+    // BCH-1156: date inputs produce YYYY-MM-DD strings; the API requires RFC3339.
+    // Passing a plain date string must result in an RFC3339 value in the URL.
+    it('converts YYYY-MM-DD date strings to RFC3339 format in query params', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({
+        dueBefore: '2024-12-31',
+        dueAfter: '2024-01-01',
+      });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      // Must contain RFC3339 timestamps, not bare YYYY-MM-DD strings
+      expect(calledUrl).toContain('due_before=2024-12-31T');
+      expect(calledUrl).toContain('due_after=2024-01-01T');
+      expect(calledUrl).not.toContain('due_before=2024-12-31&');
+      expect(calledUrl).not.toContain('due_after=2024-01-01&');
+      expect(calledUrl).not.toMatch(/due_before=2024-12-31$/);
+      expect(calledUrl).not.toMatch(/due_after=2024-01-01$/);
+    });
+
+    // BCH-1156: dueBefore must use end-of-day so tasks due ON that date are included.
+    // Sending start-of-day (T00:00:00Z) causes the API (due_date <= X) to exclude
+    // tasks whose due_date is any time after midnight on the selected day.
+    it('sends end-of-day timestamp for dueBefore so same-day tasks are included', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({ dueBefore: '2026-05-28' });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      // Must be end-of-day (T23...) not start-of-day (T00...)
+      expect(calledUrl).toContain('due_before=2026-05-28T23');
+    });
+
+    // BCH-1156: Go's time.Parse(time.RFC3339, ...) does not accept fractional seconds.
+    // toISOString() always produces milliseconds (e.g. T23:59:59.999Z) which causes
+    // a persistent 400 even after the YYYY-MM-DD → RFC3339 conversion is applied.
+    it('formats date params without milliseconds so Go time.RFC3339 can parse them', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({
+        dueBefore: '2026-05-28',
+        dueAfter: '2026-05-26',
+      });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      // Must not contain milliseconds (.000, .999, etc)
+      expect(calledUrl).not.toMatch(/due_before=.*\.\d{3}/);
+      expect(calledUrl).not.toMatch(/due_after=.*\.\d{3}/);
+      // Must end with Z (UTC) after the seconds
+      expect(calledUrl).toContain('due_before=2026-05-28T23%3A59%3A59Z');
+      expect(calledUrl).toContain('due_after=2026-05-26T00%3A00%3A00Z');
+    });
+
     it('includes all filter parameters', async () => {
       const mockResponse: MyAssignmentsResponse = {
         data: [],
@@ -126,7 +206,7 @@ describe('useMyAssignments', () => {
       });
 
       const expectedUrl =
-        '/api/workflows/step-executions/my?status=in_progress&due_before=2024-12-31&due_after=2024-01-01&workflow_definition_id=workflow-123&limit=15&offset=5';
+        '/api/workflows/step-executions/my?status=in_progress&due_before=2024-12-31T23%3A59%3A59Z&due_after=2024-01-01T00%3A00%3A00Z&workflow_definition_id=workflow-123&limit=15&offset=5';
       expect(mockExecute).toHaveBeenCalledWith(expectedUrl);
     });
 

--- a/src/composables/workflows/useMyAssignments.ts
+++ b/src/composables/workflows/useMyAssignments.ts
@@ -40,8 +40,17 @@ export function useMyAssignments() {
       const params = new URLSearchParams();
 
       if (filter.status) params.append('status', filter.status);
-      if (filter.dueBefore) params.append('due_before', filter.dueBefore);
-      if (filter.dueAfter) params.append('due_after', filter.dueAfter);
+      if (filter.dueBefore) {
+        const d = new Date(filter.dueBefore);
+        d.setUTCHours(23, 59, 59, 0);
+        params.append('due_before', d.toISOString().slice(0, 19) + 'Z');
+      }
+      if (filter.dueAfter) {
+        params.append(
+          'due_after',
+          new Date(filter.dueAfter).toISOString().slice(0, 19) + 'Z',
+        );
+      }
       if (filter.workflowDefinitionId)
         params.append('workflow_definition_id', filter.workflowDefinitionId);
       if (filter.limit) params.append('limit', filter.limit.toString());

--- a/src/composables/workflows/useMyAssignments.ts
+++ b/src/composables/workflows/useMyAssignments.ts
@@ -42,14 +42,16 @@ export function useMyAssignments() {
       if (filter.status) params.append('status', filter.status);
       if (filter.dueBefore) {
         const d = new Date(filter.dueBefore);
-        d.setUTCHours(23, 59, 59, 0);
-        params.append('due_before', d.toISOString().slice(0, 19) + 'Z');
+        if (!isNaN(d.getTime())) {
+          d.setUTCHours(23, 59, 59, 0);
+          params.append('due_before', d.toISOString().slice(0, 19) + 'Z');
+        }
       }
       if (filter.dueAfter) {
-        params.append(
-          'due_after',
-          new Date(filter.dueAfter).toISOString().slice(0, 19) + 'Z',
-        );
+        const d = new Date(filter.dueAfter);
+        if (!isNaN(d.getTime())) {
+          params.append('due_after', d.toISOString().slice(0, 19) + 'Z');
+        }
       }
       if (filter.workflowDefinitionId)
         params.append('workflow_definition_id', filter.workflowDefinitionId);

--- a/src/views/__tests__/MyTasksView.spec.ts
+++ b/src/views/__tests__/MyTasksView.spec.ts
@@ -189,6 +189,27 @@ describe('MyTasksView', () => {
     ]);
   });
 
+  // BCH-1156: simulate a real user typing into the date inputs (setValue dispatches
+  // the DOM input event that v-model listens to) and verify the filter params reach
+  // fetchMyAssignments — this mirrors actual browser behaviour unlike setting vm refs directly.
+  it('passes due-date filter params to fetchMyAssignments when date inputs are changed by the user', async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    mockFetchMyAssignments.mockClear();
+
+    await wrapper.find('#dueAfterFilter').setValue('2026-05-26');
+    await wrapper.find('#dueBeforeFilter').setValue('2026-05-28');
+    await flushPromises();
+
+    const calls = mockFetchMyAssignments.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const lastCall = calls[calls.length - 1][0];
+
+    expect(lastCall.dueAfter).toBe('2026-05-26');
+    expect(lastCall.dueBefore).toBe('2026-05-28');
+  });
+
   it('applies due-date filters when loading assignments', async () => {
     const wrapper = mountComponent();
     await flushPromises();

--- a/src/views/workflow-executions/partials/EvidenceSubmissionForm.vue
+++ b/src/views/workflow-executions/partials/EvidenceSubmissionForm.vue
@@ -32,12 +32,18 @@
           type="file"
           multiple
           @change="handleFileChange"
-          accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif"
+          :accept="fileAcceptTypes"
           class="w-full px-3 py-2 border border-ccf-300 dark:border-slate-700 rounded-md bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-200"
         />
         <small class="text-gray-500 dark:text-slate-400">
-          Supported: PDF, Word, Images (max 10MB per file, multiple files
-          allowed)
+          <template v-if="evidenceForm.type === 'screenshot'">
+            Supported: PNG, JPG, GIF, WebP (max 10MB per file, multiple files
+            allowed)
+          </template>
+          <template v-else>
+            Supported: PDF, Word, Images (max 10MB per file, multiple files
+            allowed)
+          </template>
         </small>
         <div v-if="selectedFiles.length > 0" class="mt-2 space-y-1">
           <div class="text-sm text-green-600 dark:text-green-400">
@@ -183,6 +189,22 @@ const isLinkEvidenceType = computed(() => {
   return evidenceForm.value.type === 'link';
 });
 
+const screenshotAcceptTypes = '.png,.jpg,.jpeg,.gif,.webp';
+const documentAcceptTypes = '.pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp';
+
+const fileAcceptTypes = computed(() => {
+  return evidenceForm.value.type === 'screenshot'
+    ? screenshotAcceptTypes
+    : documentAcceptTypes;
+});
+
+const screenshotAllowedMimeTypes = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
 const canSubmit = computed(() => {
   if (!evidenceForm.value.type) return false;
 
@@ -210,6 +232,18 @@ function handleFileChange(event: Event) {
       submitError.value = `The following files exceed 10MB limit: ${oversizedFiles.map((f) => f.name).join(', ')}`;
       selectedFiles.value = [];
       return;
+    }
+
+    // Validate file type compatibility with evidence type
+    if (evidenceForm.value.type === 'screenshot') {
+      const invalidFiles = files.filter(
+        (file) => !screenshotAllowedMimeTypes.has(file.type),
+      );
+      if (invalidFiles.length > 0) {
+        submitError.value = `screenshot evidence only accepts image files (PNG, JPG, GIF, WebP): ${invalidFiles.map((f) => f.name).join(', ')}`;
+        selectedFiles.value = [];
+        return;
+      }
     }
 
     selectedFiles.value = files;

--- a/src/views/workflow-executions/partials/__tests__/EvidenceSubmissionForm.spec.ts
+++ b/src/views/workflow-executions/partials/__tests__/EvidenceSubmissionForm.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import EvidenceSubmissionForm from '../EvidenceSubmissionForm.vue';
 import type { EvidenceRequirement, StepExecution } from '@/types/workflows';
 
@@ -75,5 +76,80 @@ describe('EvidenceSubmissionForm', () => {
       .map((o) => o.text().trim());
 
     expect(optionTexts).toContain('screenshot');
+  });
+
+  // BCH-1150: file input accept attribute must be restricted to image types when evidence type is screenshot.
+  // Observed: accept is static ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif" regardless of evidence type.
+  // Expected: accept only contains image extensions when type is screenshot.
+  it('restricts file input to image types when evidence type is screenshot', async () => {
+    const wrapper = mount(EvidenceSubmissionForm, {
+      props: { step, evidenceRequirements: [] },
+      global: { stubs },
+    });
+
+    // Set evidence type to screenshot via the internal form state
+    const vm = wrapper.vm as unknown as { evidenceForm: { type: string } };
+    vm.evidenceForm.type = 'screenshot';
+    await nextTick();
+
+    const fileInput = wrapper.find('input[type="file"]');
+    const accept = fileInput.attributes('accept') ?? '';
+
+    // Must contain image extensions
+    expect(accept).toContain('.png');
+    expect(accept).toContain('.jpg');
+    // Must NOT contain document extensions
+    expect(accept).not.toContain('.pdf');
+    expect(accept).not.toContain('.doc');
+  });
+
+  // BCH-1150: file input accept attribute should include document extensions when type is document.
+  it('allows document file types when evidence type is document', async () => {
+    const wrapper = mount(EvidenceSubmissionForm, {
+      props: { step, evidenceRequirements: [] },
+      global: { stubs },
+    });
+
+    const vm = wrapper.vm as unknown as { evidenceForm: { type: string } };
+    vm.evidenceForm.type = 'document';
+    await nextTick();
+
+    const fileInput = wrapper.find('input[type="file"]');
+    const accept = fileInput.attributes('accept') ?? '';
+
+    expect(accept).toContain('.pdf');
+  });
+
+  // BCH-1150: selecting a non-image file when evidence type is screenshot should show an error.
+  // Observed: handleFileChange only validates file size, not type compatibility.
+  // Expected: an error message is shown when a PDF is selected for screenshot evidence.
+  it('shows an error when a non-image file is selected for screenshot evidence', async () => {
+    const wrapper = mount(EvidenceSubmissionForm, {
+      props: { step, evidenceRequirements: [] },
+      global: { stubs },
+    });
+
+    const vm = wrapper.vm as unknown as {
+      evidenceForm: { type: string };
+      handleFileChange: (e: Event) => void;
+      submitError: string;
+    };
+
+    vm.evidenceForm.type = 'screenshot';
+    await nextTick();
+
+    const pdfFile = new File(['content'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+    const input = wrapper.find('input[type="file"]')
+      .element as HTMLInputElement;
+    Object.defineProperty(input, 'files', {
+      value: [pdfFile],
+      configurable: true,
+    });
+    await wrapper.find('input[type="file"]').trigger('change');
+
+    expect(vm.submitError).toBeTruthy();
+    expect(vm.submitError).toContain('screenshot');
   });
 });


### PR DESCRIPTION
Make accept attribute dynamic based on evidence type (image-only for
    screenshot, broader for document). Reject non-image files in
    handleFileChange when evidence type is screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence upload form now validates file types based on evidence type—screenshots require image formats, documents support standard document formats.

* **Bug Fixes**
  * Due date filters now correctly convert to UTC timestamps (RFC3339 format) for accurate backend API queries.

* **Tests**
  * Added comprehensive test coverage for date filter conversion and evidence file type validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->