### PR TITLE
Fix/bch 1156

### DIFF
--- a/src/composables/__tests__/usePoamItems.spec.ts
+++ b/src/composables/__tests__/usePoamItems.spec.ts
@@ -389,9 +389,7 @@ describe('usePoamItems', () => {
 
     it('accepts an empty payload (all fields optional)', async () => {
       const { promoteRiskToPoam } = usePromoteRiskToPoam();
-      await expect(
-        promoteRiskToPoam('ssp-123', 'risk-abc', {}),
-      ).resolves.not.toThrow();
+      await promoteRiskToPoam('ssp-123', 'risk-abc', {});
     });
   });
 

--- a/src/composables/__tests__/usePoamItems.spec.ts
+++ b/src/composables/__tests__/usePoamItems.spec.ts
@@ -389,7 +389,9 @@ describe('usePoamItems', () => {
 
     it('accepts an empty payload (all fields optional)', async () => {
       const { promoteRiskToPoam } = usePromoteRiskToPoam();
-      await promoteRiskToPoam('ssp-123', 'risk-abc', {});
+      await expect(
+        promoteRiskToPoam('ssp-123', 'risk-abc', {}),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -155,6 +155,26 @@ describe('useMyAssignments', () => {
       expect(calledUrl).toContain('due_before=2026-05-28T23');
     });
 
+    // BCH-1156-3: dueAfter must be normalized to UTC start-of-day even when the
+    // input string contains a time component, so the lower-bound filter is consistent.
+    it('normalizes dueAfter to UTC start-of-day regardless of input time component', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({ dueAfter: '2024-06-15T15:30:00Z' });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('due_after=2024-06-15T00%3A00%3A00Z');
+    });
+
     // BCH-1156: Go's time.Parse(time.RFC3339, ...) does not accept fractional seconds.
     // toISOString() always produces milliseconds (e.g. T23:59:59.999Z) which causes
     // a persistent 400 even after the YYYY-MM-DD → RFC3339 conversion is applied.

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -484,7 +484,7 @@ describe('useMyAssignments', () => {
       const { fetchMyAssignments } = useMyAssignments();
       await expect(
         fetchMyAssignments({ dueBefore: 'not-a-date', dueAfter: 'also-bad' }),
-      ).resolves.not.toThrow();
+      ).resolves.toBeDefined();
 
       const calledUrl = mockExecute.mock.calls[0][0] as string;
       expect(calledUrl).not.toContain('due_before');

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -469,6 +469,28 @@ describe('useMyAssignments', () => {
   });
 
   describe('edge cases', () => {
+    // new Date('not-a-date').toISOString() throws RangeError; invalid strings must
+    // be silently dropped so the API call still proceeds without the bad param.
+    it('silently omits due date params when the date string is invalid', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await expect(
+        fetchMyAssignments({ dueBefore: 'not-a-date', dueAfter: 'also-bad' }),
+      ).resolves.not.toThrow();
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain('due_before');
+      expect(calledUrl).not.toContain('due_after');
+    });
+
     it('handles empty results', async () => {
       const mockResponse: MyAssignmentsResponse = {
         data: [],

--- a/src/composables/workflows/__tests__/useMyAssignments.spec.ts
+++ b/src/composables/workflows/__tests__/useMyAssignments.spec.ts
@@ -104,6 +104,86 @@ describe('useMyAssignments', () => {
       );
     });
 
+    // BCH-1156: date inputs produce YYYY-MM-DD strings; the API requires RFC3339.
+    // Passing a plain date string must result in an RFC3339 value in the URL.
+    it('converts YYYY-MM-DD date strings to RFC3339 format in query params', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({
+        dueBefore: '2024-12-31',
+        dueAfter: '2024-01-01',
+      });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      // Must contain RFC3339 timestamps, not bare YYYY-MM-DD strings
+      expect(calledUrl).toContain('due_before=2024-12-31T');
+      expect(calledUrl).toContain('due_after=2024-01-01T');
+      expect(calledUrl).not.toContain('due_before=2024-12-31&');
+      expect(calledUrl).not.toContain('due_after=2024-01-01&');
+      expect(calledUrl).not.toMatch(/due_before=2024-12-31$/);
+      expect(calledUrl).not.toMatch(/due_after=2024-01-01$/);
+    });
+
+    // BCH-1156: dueBefore must use end-of-day so tasks due ON that date are included.
+    // Sending start-of-day (T00:00:00Z) causes the API (due_date <= X) to exclude
+    // tasks whose due_date is any time after midnight on the selected day.
+    it('sends end-of-day timestamp for dueBefore so same-day tasks are included', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({ dueBefore: '2026-05-28' });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      // Must be end-of-day (T23...) not start-of-day (T00...)
+      expect(calledUrl).toContain('due_before=2026-05-28T23');
+    });
+
+    // BCH-1156: Go's time.Parse(time.RFC3339, ...) does not accept fractional seconds.
+    // toISOString() always produces milliseconds (e.g. T23:59:59.999Z) which causes
+    // a persistent 400 even after the YYYY-MM-DD → RFC3339 conversion is applied.
+    it('formats date params without milliseconds so Go time.RFC3339 can parse them', async () => {
+      const emptyResponse: MyAssignmentsResponse = {
+        data: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        hasMore: false,
+      };
+
+      setMockResponse(emptyResponse);
+
+      const { fetchMyAssignments } = useMyAssignments();
+      await fetchMyAssignments({
+        dueBefore: '2026-05-28',
+        dueAfter: '2026-05-26',
+      });
+
+      const calledUrl = mockExecute.mock.calls[0][0] as string;
+      // Must not contain milliseconds (.000, .999, etc)
+      expect(calledUrl).not.toMatch(/due_before=.*\.\d{3}/);
+      expect(calledUrl).not.toMatch(/due_after=.*\.\d{3}/);
+      // Must end with Z (UTC) after the seconds
+      expect(calledUrl).toContain('due_before=2026-05-28T23%3A59%3A59Z');
+      expect(calledUrl).toContain('due_after=2026-05-26T00%3A00%3A00Z');
+    });
+
     it('includes all filter parameters', async () => {
       const mockResponse: MyAssignmentsResponse = {
         data: [],
@@ -126,7 +206,7 @@ describe('useMyAssignments', () => {
       });
 
       const expectedUrl =
-        '/api/workflows/step-executions/my?status=in_progress&due_before=2024-12-31&due_after=2024-01-01&workflow_definition_id=workflow-123&limit=15&offset=5';
+        '/api/workflows/step-executions/my?status=in_progress&due_before=2024-12-31T23%3A59%3A59Z&due_after=2024-01-01T00%3A00%3A00Z&workflow_definition_id=workflow-123&limit=15&offset=5';
       expect(mockExecute).toHaveBeenCalledWith(expectedUrl);
     });
 

--- a/src/composables/workflows/useMyAssignments.ts
+++ b/src/composables/workflows/useMyAssignments.ts
@@ -40,8 +40,17 @@ export function useMyAssignments() {
       const params = new URLSearchParams();
 
       if (filter.status) params.append('status', filter.status);
-      if (filter.dueBefore) params.append('due_before', filter.dueBefore);
-      if (filter.dueAfter) params.append('due_after', filter.dueAfter);
+      if (filter.dueBefore) {
+        const d = new Date(filter.dueBefore);
+        d.setUTCHours(23, 59, 59, 0);
+        params.append('due_before', d.toISOString().slice(0, 19) + 'Z');
+      }
+      if (filter.dueAfter) {
+        params.append(
+          'due_after',
+          new Date(filter.dueAfter).toISOString().slice(0, 19) + 'Z',
+        );
+      }
       if (filter.workflowDefinitionId)
         params.append('workflow_definition_id', filter.workflowDefinitionId);
       if (filter.limit) params.append('limit', filter.limit.toString());

--- a/src/composables/workflows/useMyAssignments.ts
+++ b/src/composables/workflows/useMyAssignments.ts
@@ -50,6 +50,7 @@ export function useMyAssignments() {
       if (filter.dueAfter) {
         const d = new Date(filter.dueAfter);
         if (!isNaN(d.getTime())) {
+          d.setUTCHours(0, 0, 0, 0);
           params.append('due_after', d.toISOString().slice(0, 19) + 'Z');
         }
       }

--- a/src/composables/workflows/useMyAssignments.ts
+++ b/src/composables/workflows/useMyAssignments.ts
@@ -42,14 +42,16 @@ export function useMyAssignments() {
       if (filter.status) params.append('status', filter.status);
       if (filter.dueBefore) {
         const d = new Date(filter.dueBefore);
-        d.setUTCHours(23, 59, 59, 0);
-        params.append('due_before', d.toISOString().slice(0, 19) + 'Z');
+        if (!isNaN(d.getTime())) {
+          d.setUTCHours(23, 59, 59, 0);
+          params.append('due_before', d.toISOString().slice(0, 19) + 'Z');
+        }
       }
       if (filter.dueAfter) {
-        params.append(
-          'due_after',
-          new Date(filter.dueAfter).toISOString().slice(0, 19) + 'Z',
-        );
+        const d = new Date(filter.dueAfter);
+        if (!isNaN(d.getTime())) {
+          params.append('due_after', d.toISOString().slice(0, 19) + 'Z');
+        }
       }
       if (filter.workflowDefinitionId)
         params.append('workflow_definition_id', filter.workflowDefinitionId);

--- a/src/views/__tests__/MyTasksView.spec.ts
+++ b/src/views/__tests__/MyTasksView.spec.ts
@@ -189,6 +189,27 @@ describe('MyTasksView', () => {
     ]);
   });
 
+  // BCH-1156: simulate a real user typing into the date inputs (setValue dispatches
+  // the DOM input event that v-model listens to) and verify the filter params reach
+  // fetchMyAssignments — this mirrors actual browser behaviour unlike setting vm refs directly.
+  it('passes due-date filter params to fetchMyAssignments when date inputs are changed by the user', async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    mockFetchMyAssignments.mockClear();
+
+    await wrapper.find('#dueAfterFilter').setValue('2026-05-26');
+    await wrapper.find('#dueBeforeFilter').setValue('2026-05-28');
+    await flushPromises();
+
+    const calls = mockFetchMyAssignments.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const lastCall = calls[calls.length - 1][0];
+
+    expect(lastCall.dueAfter).toBe('2026-05-26');
+    expect(lastCall.dueBefore).toBe('2026-05-28');
+  });
+
   it('applies due-date filters when loading assignments', async () => {
     const wrapper = mountComponent();
     await flushPromises();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Due-date filtering now normalizes inputs to UTC start/end-of-day, serializes timestamps without fractional seconds, and omits invalid dates.
  * Same-day tasks are correctly included via end-of-day normalization.

* **Tests**
  * Expanded unit tests covering RFC3339 date serialization, omission of invalid dates, and due-date input interactions.
  * Updated a test to expect an empty-payload call to resolve to undefined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->