### PR TITLE
BCH-1150: Restrict file input accept types and validate on selection …

### DIFF
--- a/src/views/workflow-executions/partials/EvidenceSubmissionForm.vue
+++ b/src/views/workflow-executions/partials/EvidenceSubmissionForm.vue
@@ -32,12 +32,18 @@
           type="file"
           multiple
           @change="handleFileChange"
-          accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif"
+          :accept="fileAcceptTypes"
           class="w-full px-3 py-2 border border-ccf-300 dark:border-slate-700 rounded-md bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-200"
         />
         <small class="text-gray-500 dark:text-slate-400">
-          Supported: PDF, Word, Images (max 10MB per file, multiple files
-          allowed)
+          <template v-if="evidenceForm.type === 'screenshot'">
+            Supported: PNG, JPG, GIF, WebP (max 10MB per file, multiple files
+            allowed)
+          </template>
+          <template v-else>
+            Supported: PDF, Word, Images (max 10MB per file, multiple files
+            allowed)
+          </template>
         </small>
         <div v-if="selectedFiles.length > 0" class="mt-2 space-y-1">
           <div class="text-sm text-green-600 dark:text-green-400">
@@ -183,6 +189,22 @@ const isLinkEvidenceType = computed(() => {
   return evidenceForm.value.type === 'link';
 });
 
+const screenshotAcceptTypes = '.png,.jpg,.jpeg,.gif,.webp';
+const documentAcceptTypes = '.pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp';
+
+const fileAcceptTypes = computed(() => {
+  return evidenceForm.value.type === 'screenshot'
+    ? screenshotAcceptTypes
+    : documentAcceptTypes;
+});
+
+const screenshotAllowedMimeTypes = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
 const canSubmit = computed(() => {
   if (!evidenceForm.value.type) return false;
 
@@ -210,6 +232,18 @@ function handleFileChange(event: Event) {
       submitError.value = `The following files exceed 10MB limit: ${oversizedFiles.map((f) => f.name).join(', ')}`;
       selectedFiles.value = [];
       return;
+    }
+
+    // Validate file type compatibility with evidence type
+    if (evidenceForm.value.type === 'screenshot') {
+      const invalidFiles = files.filter(
+        (file) => !screenshotAllowedMimeTypes.has(file.type),
+      );
+      if (invalidFiles.length > 0) {
+        submitError.value = `screenshot evidence only accepts image files (PNG, JPG, GIF, WebP): ${invalidFiles.map((f) => f.name).join(', ')}`;
+        selectedFiles.value = [];
+        return;
+      }
     }
 
     selectedFiles.value = files;

--- a/src/views/workflow-executions/partials/__tests__/EvidenceSubmissionForm.spec.ts
+++ b/src/views/workflow-executions/partials/__tests__/EvidenceSubmissionForm.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import EvidenceSubmissionForm from '../EvidenceSubmissionForm.vue';
 import type { EvidenceRequirement, StepExecution } from '@/types/workflows';
 
@@ -75,5 +76,80 @@ describe('EvidenceSubmissionForm', () => {
       .map((o) => o.text().trim());
 
     expect(optionTexts).toContain('screenshot');
+  });
+
+  // BCH-1150: file input accept attribute must be restricted to image types when evidence type is screenshot.
+  // Observed: accept is static ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif" regardless of evidence type.
+  // Expected: accept only contains image extensions when type is screenshot.
+  it('restricts file input to image types when evidence type is screenshot', async () => {
+    const wrapper = mount(EvidenceSubmissionForm, {
+      props: { step, evidenceRequirements: [] },
+      global: { stubs },
+    });
+
+    // Set evidence type to screenshot via the internal form state
+    const vm = wrapper.vm as unknown as { evidenceForm: { type: string } };
+    vm.evidenceForm.type = 'screenshot';
+    await nextTick();
+
+    const fileInput = wrapper.find('input[type="file"]');
+    const accept = fileInput.attributes('accept') ?? '';
+
+    // Must contain image extensions
+    expect(accept).toContain('.png');
+    expect(accept).toContain('.jpg');
+    // Must NOT contain document extensions
+    expect(accept).not.toContain('.pdf');
+    expect(accept).not.toContain('.doc');
+  });
+
+  // BCH-1150: file input accept attribute should include document extensions when type is document.
+  it('allows document file types when evidence type is document', async () => {
+    const wrapper = mount(EvidenceSubmissionForm, {
+      props: { step, evidenceRequirements: [] },
+      global: { stubs },
+    });
+
+    const vm = wrapper.vm as unknown as { evidenceForm: { type: string } };
+    vm.evidenceForm.type = 'document';
+    await nextTick();
+
+    const fileInput = wrapper.find('input[type="file"]');
+    const accept = fileInput.attributes('accept') ?? '';
+
+    expect(accept).toContain('.pdf');
+  });
+
+  // BCH-1150: selecting a non-image file when evidence type is screenshot should show an error.
+  // Observed: handleFileChange only validates file size, not type compatibility.
+  // Expected: an error message is shown when a PDF is selected for screenshot evidence.
+  it('shows an error when a non-image file is selected for screenshot evidence', async () => {
+    const wrapper = mount(EvidenceSubmissionForm, {
+      props: { step, evidenceRequirements: [] },
+      global: { stubs },
+    });
+
+    const vm = wrapper.vm as unknown as {
+      evidenceForm: { type: string };
+      handleFileChange: (e: Event) => void;
+      submitError: string;
+    };
+
+    vm.evidenceForm.type = 'screenshot';
+    await nextTick();
+
+    const pdfFile = new File(['content'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+    const input = wrapper.find('input[type="file"]')
+      .element as HTMLInputElement;
+    Object.defineProperty(input, 'files', {
+      value: [pdfFile],
+      configurable: true,
+    });
+    await wrapper.find('input[type="file"]').trigger('change');
+
+    expect(vm.submitError).toBeTruthy();
+    expect(vm.submitError).toContain('screenshot');
   });
 });


### PR DESCRIPTION
…for screenshot evidence

Make accept attribute dynamic based on evidence type (image-only for screenshot, broader for document). Reject non-image files in handleFileChange when evidence type is screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence file uploads now dynamically restrict accepted file types based on the selected evidence type. Screenshots accept image formats including WebP, while document submissions accept document formats. The uploader displays relevant supported formats and rejects incompatible files with clear error guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->