### PR TITLE
Fix/bch 1284

### DIFF
--- a/src/views/evidence/partial/EvidenceForm.vue
+++ b/src/views/evidence/partial/EvidenceForm.vue
@@ -198,8 +198,8 @@ const labels = ref<EvidenceLabel[]>(props.evidence?.labels || []);
 const dateValidationError = computed(() => {
   if (!evidence.value.start || !evidence.value.end) return null;
 
-  const startDate = new Date(evidence.value.start);
-  const endDate = new Date(evidence.value.end);
+  const startDate = evidence.value.start;
+  const endDate = evidence.value.end;
   const today = new Date();
   today.setHours(23, 59, 59, 999);
 

--- a/src/views/evidence/partial/EvidenceForm.vue
+++ b/src/views/evidence/partial/EvidenceForm.vue
@@ -74,6 +74,7 @@
                     ? new Date(evidence.start)
                     : new Date(Date.now())
                 "
+                :max-date="new Date(Date.now())"
               />
               <div v-if="dateValidationError" class="text-red-500 text-sm mt-1">
                 {{ dateValidationError }}
@@ -199,7 +200,12 @@ const dateValidationError = computed(() => {
 
   const startDate = new Date(evidence.value.start);
   const endDate = new Date(evidence.value.end);
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
 
+  if (endDate > today) {
+    return 'End date cannot be in the future';
+  }
   if (startDate > endDate) {
     return 'End date must be after start date';
   }

--- a/src/views/evidence/partial/__tests__/EvidenceForm.spec.ts
+++ b/src/views/evidence/partial/__tests__/EvidenceForm.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import EvidenceForm from '../EvidenceForm.vue';
+
+vi.mock('uuid', () => ({
+  v4: () => 'test-uuid',
+}));
+
+const mountedWrappers: Array<ReturnType<typeof mount>> = [];
+
+function mountForm(props: Record<string, unknown> = {}) {
+  const wrapper = mount(EvidenceForm, {
+    props: {
+      backmatterResources: [],
+      ...props,
+    },
+    global: {
+      stubs: {
+        DatePicker: {
+          props: [
+            'modelValue',
+            'maxDate',
+            'minDate',
+            'placeholder',
+            'required',
+            'dateFormat',
+          ],
+          emits: ['update:modelValue'],
+          template: '<div data-testid="date-picker"></div>',
+        },
+        InputText: {
+          props: ['modelValue', 'id', 'required', 'class'],
+          emits: ['update:modelValue'],
+          template:
+            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        },
+        Textarea: {
+          props: ['modelValue', 'id', 'class'],
+          emits: ['update:modelValue'],
+          template:
+            '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)"></textarea>',
+        },
+        SelectButton: {
+          props: ['modelValue', 'options', 'required'],
+          emits: ['update:modelValue'],
+          template: '<div></div>',
+        },
+        TertiaryButton: {
+          props: ['type', 'class'],
+          emits: ['click'],
+          template:
+            '<button :type="type" @click="$emit(\'click\')"><slot /></button>',
+        },
+        PrimaryButton: {
+          props: ['type', 'disabled'],
+          emits: ['click'],
+          template:
+            '<button :type="type || \'submit\'" :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+        },
+        SecondaryButton: {
+          props: ['size', 'type'],
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+        },
+        Base64FileUpload: {
+          emits: ['uploaded'],
+          template: '<div></div>',
+        },
+        BIconArrowRepeat: { template: '<span></span>' },
+        BIconX: { template: '<span></span>' },
+      },
+    },
+  });
+  mountedWrappers.push(wrapper);
+  return wrapper;
+}
+
+describe('EvidenceForm', () => {
+  afterEach(() => {
+    for (const wrapper of mountedWrappers) {
+      wrapper.unmount();
+    }
+    mountedWrappers.length = 0;
+  });
+
+  // BCH-1284: End date in the future should be rejected with an inline error.
+  // Observed: form is submittable with a future end date, resulting in a 400 from the API.
+  // Expected: form is blocked and shows an inline error when the end date is in the future.
+  it('disables the submit button and shows an inline error when the end date is in the future', async () => {
+    const wrapper = mountForm({
+      evidence: {
+        start: '2024-01-01T00:00:00Z',
+        end: '2027-01-01T00:00:00Z',
+      },
+    });
+
+    await flushPromises();
+
+    const submitButton = wrapper.find('button[type="submit"]');
+    expect(submitButton.attributes('disabled')).toBeDefined();
+
+    const errorMessage = wrapper.find('.text-red-500');
+    expect(errorMessage.exists()).toBe(true);
+    expect(errorMessage.text()).toContain('future');
+  });
+});

--- a/src/views/evidence/partial/__tests__/EvidenceForm.spec.ts
+++ b/src/views/evidence/partial/__tests__/EvidenceForm.spec.ts
@@ -87,10 +87,13 @@ describe('EvidenceForm', () => {
   // Observed: form is submittable with a future end date, resulting in a 400 from the API.
   // Expected: form is blocked and shows an inline error when the end date is in the future.
   it('disables the submit button and shows an inline error when the end date is in the future', async () => {
+    const futureEnd = new Date(
+      Date.now() + 365 * 24 * 60 * 60 * 1000,
+    ).toISOString();
     const wrapper = mountForm({
       evidence: {
         start: '2024-01-01T00:00:00Z',
-        end: '2027-01-01T00:00:00Z',
+        end: futureEnd,
       },
     });
 


### PR DESCRIPTION
  What the fix delivers (two layers):
  1. Calendar UI (max-date="new Date(Date.now())" on the end date DatePicker): future dates
  are grayed and blocked — proven in the screenshot
  2. JS validation (dateValidationError computed property): if a future date somehow gets
  set, the form shows "End date cannot be in the future" and disables the submit button —
  proven by the passing unit test

  The inline error message (the ticket's second expected behaviour) requires a future date to
   actually be set. Since the calendar fix correctly prevents that, the error can only be
  triggered by bypassing the UI — which is exactly how the test exercises it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * End Date validation now prevents selecting future dates; choosing a future date shows a validation error and disables the submit button.
  * Date picker now constrains selectable dates up to the current day.

* **Tests**
  * Added a test verifying behavior for future End Date: submit is disabled and the inline error is shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compliance-framework/ui/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->