### PR TITLE
fix: support for mutiple profiles in several pages

### DIFF
--- a/src/views/dashboard/CompliancePostureWidget.vue
+++ b/src/views/dashboard/CompliancePostureWidget.vue
@@ -135,6 +135,7 @@ import PageHeader from '@/components/PageHeader.vue';
 import PageSubHeader from '@/components/PageSubHeader.vue';
 import PageCard from '@/components/PageCard.vue';
 import { useDataApi } from '@/composables/axios';
+import { useSystemSecurityPlanStore } from '@/stores/system-security-plans';
 import type { SystemSecurityPlan } from '@/oscal';
 import type { ProfileComplianceSummary } from '@/types/compliance';
 import { computeComplianceWidths } from '@/utils/compliance';
@@ -148,6 +149,7 @@ interface ComplianceItem {
 }
 
 const router = useRouter();
+const sspStore = useSystemSecurityPlanStore();
 const complianceItems = ref<ComplianceItem[]>([]);
 const isLoading = ref(true);
 
@@ -162,10 +164,6 @@ const gridClass = computed(() => {
 const { execute: fetchSSPs } = useDataApi<SystemSecurityPlan[]>(null, null, {
   immediate: false,
 });
-
-const { execute: fetchProfileBindings } = useDataApi<
-  Array<{ id?: string; uuid?: string; title?: string }>
->(null, null, { immediate: false });
 
 interface ComplianceProgressResponse {
   summary: ProfileComplianceSummary;
@@ -192,16 +190,10 @@ onMounted(async () => {
 
     for (const ssp of ssps) {
       try {
-        const { data: bindingsData } = await fetchProfileBindings(
-          `/api/oscal/system-security-plans/${ssp.uuid}/profiles`,
-        );
-        const bindings = bindingsData.value?.data || [];
+        const { data: bindings } = await sspStore.listProfiles(ssp.uuid);
 
         for (const binding of bindings) {
-          const profileUuid = binding.uuid || binding.id;
-          if (!profileUuid) {
-            continue;
-          }
+          const profileUuid = binding.uuid;
 
           try {
             const { data: complianceData } = await fetchCompliance(

--- a/src/views/dashboard/CompliancePostureWidget.vue
+++ b/src/views/dashboard/CompliancePostureWidget.vue
@@ -8,7 +8,7 @@
     <div :class="gridClass">
       <PageCard
         v-for="item in complianceItems"
-        :key="item.sspId"
+        :key="`${item.sspId}:${item.profileId}`"
         class="cursor-pointer transition-shadow hover:shadow-md"
         role="button"
         tabindex="0"
@@ -135,12 +135,13 @@ import PageHeader from '@/components/PageHeader.vue';
 import PageSubHeader from '@/components/PageSubHeader.vue';
 import PageCard from '@/components/PageCard.vue';
 import { useDataApi } from '@/composables/axios';
-import type { SystemSecurityPlan, Profile } from '@/oscal';
+import type { SystemSecurityPlan } from '@/oscal';
 import type { ProfileComplianceSummary } from '@/types/compliance';
 import { computeComplianceWidths } from '@/utils/compliance';
 
 interface ComplianceItem {
   sspId: string;
+  profileId: string;
   sspTitle: string;
   profileTitle: string;
   summary: ProfileComplianceSummary;
@@ -162,9 +163,9 @@ const { execute: fetchSSPs } = useDataApi<SystemSecurityPlan[]>(null, null, {
   immediate: false,
 });
 
-const { execute: fetchProfile } = useDataApi<Profile>(null, null, {
-  immediate: false,
-});
+const { execute: fetchProfileBindings } = useDataApi<
+  Array<{ id?: string; uuid?: string; title?: string }>
+>(null, null, { immediate: false });
 
 interface ComplianceProgressResponse {
   summary: ProfileComplianceSummary;
@@ -191,28 +192,37 @@ onMounted(async () => {
 
     for (const ssp of ssps) {
       try {
-        const { data: profileData } = await fetchProfile(
-          `/api/oscal/system-security-plans/${ssp.uuid}/profile`,
+        const { data: bindingsData } = await fetchProfileBindings(
+          `/api/oscal/system-security-plans/${ssp.uuid}/profiles`,
         );
-        const profile = profileData.value?.data;
-        if (!profile) {
-          continue;
-        }
+        const bindings = bindingsData.value?.data || [];
 
-        const { data: complianceData } = await fetchCompliance(
-          `/api/oscal/profiles/${profile.uuid}/compliance-progress?includeControls=false`,
-        );
-        const progress = complianceData.value?.data;
-        if (!progress?.summary) {
-          continue;
-        }
+        for (const binding of bindings) {
+          const profileUuid = binding.uuid || binding.id;
+          if (!profileUuid) {
+            continue;
+          }
 
-        results.push({
-          sspId: ssp.uuid,
-          sspTitle: ssp.metadata?.title || 'Untitled SSP',
-          profileTitle: profile.metadata?.title || 'Untitled Profile',
-          summary: progress.summary,
-        });
+          try {
+            const { data: complianceData } = await fetchCompliance(
+              `/api/oscal/profiles/${profileUuid}/compliance-progress?includeControls=false`,
+            );
+            const progress = complianceData.value?.data;
+            if (!progress?.summary) {
+              continue;
+            }
+
+            results.push({
+              sspId: ssp.uuid,
+              profileId: profileUuid,
+              sspTitle: ssp.metadata?.title || 'Untitled SSP',
+              profileTitle: binding.title || 'Untitled Profile',
+              summary: progress.summary,
+            });
+          } catch {
+            // Skip profiles with errors
+          }
+        }
       } catch {
         // Skip SSPs without profiles or with errors
       }

--- a/src/views/risk/RiskDetailView.vue
+++ b/src/views/risk/RiskDetailView.vue
@@ -1271,6 +1271,7 @@ import PromoteToPoamModal from '@/components/risk/PromoteToPoamModal.vue';
 import RiskOwnerAssignment from '@/components/risk/RiskOwnerAssignment.vue';
 import RiskPoamItemsTab from '@/components/risk/RiskPoamItemsTab.vue';
 import { useSystemStore } from '@/stores/system';
+import { useSystemSecurityPlanStore } from '@/stores/system-security-plans';
 import type { Risk, SystemComponent } from '@/oscal';
 import type { Evidence, EvidenceLabel } from '@/stores/evidence';
 import { useToast } from 'primevue/usetoast';
@@ -1437,6 +1438,7 @@ const route = useRoute();
 const router = useRouter();
 const toast = useToast();
 const systemStore = useSystemStore();
+const sspStore = useSystemSecurityPlanStore();
 const authenticatedApi = useAuthenticatedInstance();
 
 const riskId = computed(() => route.params.riskId as string | undefined);
@@ -3636,12 +3638,8 @@ async function ensureControlOptions() {
 
   loadingProfileBindings.value = true;
   try {
-    const bindingsResponse = await authenticatedApi.get<
-      DataResponse<Array<{ id?: string; uuid?: string }>>
-    >(`/api/oscal/system-security-plans/${sspId}/profiles`);
-    const profileIds = (bindingsResponse?.data?.data || [])
-      .map((binding) => binding.uuid || binding.id)
-      .filter((id): id is string => !!id);
+    const { data: bindings } = await sspStore.listProfiles(sspId);
+    const profileIds = bindings.map((binding) => binding.uuid);
 
     // An SSP can have several profiles attached; aggregate the resolved
     // controls of all of them so links against any attached profile resolve.

--- a/src/views/risk/RiskDetailView.vue
+++ b/src/views/risk/RiskDetailView.vue
@@ -1271,7 +1271,7 @@ import PromoteToPoamModal from '@/components/risk/PromoteToPoamModal.vue';
 import RiskOwnerAssignment from '@/components/risk/RiskOwnerAssignment.vue';
 import RiskPoamItemsTab from '@/components/risk/RiskPoamItemsTab.vue';
 import { useSystemStore } from '@/stores/system';
-import type { Profile, Risk, SystemComponent } from '@/oscal';
+import type { Risk, SystemComponent } from '@/oscal';
 import type { Evidence, EvidenceLabel } from '@/stores/evidence';
 import { useToast } from 'primevue/usetoast';
 import {
@@ -1579,17 +1579,11 @@ const {
   execute: executeLoadComponents,
 } = useDataApi<SystemComponent[]>(null, {}, { immediate: false });
 
-const {
-  data: profile,
-  isLoading: loadingProfile,
-  execute: executeLoadProfile,
-} = useDataApi<Profile>(null, {}, { immediate: false });
+const loadingProfileBindings = ref(false);
 
-const {
-  data: availableControlsWithCatalog,
-  isLoading: loadingResolvedControls,
-  execute: executeLoadResolvedControls,
-} = useDataApi<ResolvedControlWithCatalog[]>(null, {}, { immediate: false });
+const availableControlsWithCatalog = ref<
+  ResolvedControlWithCatalog[] | undefined
+>(undefined);
 
 const risk = ref<Risk | null>(null);
 const riskEvents = ref<RiskEventItem[]>([]);
@@ -2576,7 +2570,6 @@ watch(associationsSspId, (next, prev) => {
   evidenceOptionsLoaded.value = false;
   availableComponents.value = undefined;
   availableEvidence.value = undefined;
-  profile.value = undefined;
   availableControlsWithCatalog.value = undefined;
   evidenceDetailCache.clear();
   componentDetailCache.clear();
@@ -3636,31 +3629,52 @@ async function ensureControlOptions() {
 
   if (loadedControlsSspId.value !== sspId) {
     loadedControlsSspId.value = sspId;
-    profile.value = undefined;
     availableControlsWithCatalog.value = undefined;
   }
 
   if (availableControlsWithCatalog.value !== undefined) return;
 
-  if (!profile.value) {
-    await executeLoadProfile(
-      `/api/oscal/system-security-plans/${sspId}/profile`,
-    );
-  }
-
-  if (!profile.value?.uuid) return;
-
+  loadingProfileBindings.value = true;
   try {
-    await executeLoadResolvedControls(
-      `/api/oscal/profiles/${profile.value.uuid}/resolved-with-catalogs`,
+    const bindingsResponse = await authenticatedApi.get<
+      DataResponse<Array<{ id?: string; uuid?: string }>>
+    >(`/api/oscal/system-security-plans/${sspId}/profiles`);
+    const profileIds = (bindingsResponse?.data?.data || [])
+      .map((binding) => binding.uuid || binding.id)
+      .filter((id): id is string => !!id);
+
+    // An SSP can have several profiles attached; aggregate the resolved
+    // controls of all of them so links against any attached profile resolve.
+    const results = await Promise.allSettled(
+      profileIds.map((bindingProfileId) =>
+        authenticatedApi.get<DataResponse<ResolvedControlWithCatalog[]>>(
+          `/api/oscal/profiles/${bindingProfileId}/resolved-with-catalogs`,
+        ),
+      ),
     );
-    if (availableControlsWithCatalog.value !== undefined) {
-      return;
-    }
+
+    const merged: ResolvedControlWithCatalog[] = [];
+    const seen = new Set<string>();
+    results.forEach((result) => {
+      if (result.status !== 'fulfilled') return;
+      (result.value?.data?.data || []).forEach((item) => {
+        if (!item?.controlId) return;
+        const key =
+          controlCompositeKey(item.catalogId, item.controlId) || item.controlId;
+        if (seen.has(key)) return;
+        seen.add(key);
+        merged.push(item);
+      });
+    });
+
+    availableControlsWithCatalog.value = merged;
+    return;
   } catch (err) {
     if (isCanceledError(err)) {
       throw err;
     }
+  } finally {
+    loadingProfileBindings.value = false;
   }
 
   availableControlsWithCatalog.value = [];
@@ -4132,7 +4146,7 @@ const pickerLoading = computed(() => {
     case 'evidence':
       return loadingEvidence.value;
     case 'controls':
-      return loadingProfile.value || loadingResolvedControls.value;
+      return loadingProfileBindings.value;
     case 'components':
       return loadingComponents.value;
     default:

--- a/src/views/risk/__tests__/RiskDetailView.spec.ts
+++ b/src/views/risk/__tests__/RiskDetailView.spec.ts
@@ -330,6 +330,22 @@ vi.mock('@/composables/axios', () => ({
         };
       }
 
+      if (endpoint === '/api/oscal/system-security-plans/ssp-1/profiles') {
+        return {
+          data: {
+            data: [{ id: 'profile-1', title: 'Profile One' }],
+          },
+        };
+      }
+
+      if (endpoint === '/api/oscal/profiles/profile-1/resolved-with-catalogs') {
+        return {
+          data: {
+            data: [...mockApiState.resolvedControls],
+          },
+        };
+      }
+
       return { data: { data: undefined } };
     }),
   }),

--- a/src/views/risk/__tests__/RiskDetailView.spec.ts
+++ b/src/views/risk/__tests__/RiskDetailView.spec.ts
@@ -299,6 +299,14 @@ vi.mock('@/stores/system', () => ({
   }),
 }));
 
+vi.mock('@/stores/system-security-plans', () => ({
+  useSystemSecurityPlanStore: () => ({
+    listProfiles: vi.fn(async () => ({
+      data: [{ uuid: 'profile-1', title: 'Profile One' }],
+    })),
+  }),
+}));
+
 vi.mock('primevue/usetoast', () => ({
   useToast: () => ({
     add: mockToastAdd,
@@ -326,14 +334,6 @@ vi.mock('@/composables/axios', () => ({
               start: '2026-03-03T10:00:00Z',
               end: '2026-03-04T10:00:00Z',
             },
-          },
-        };
-      }
-
-      if (endpoint === '/api/oscal/system-security-plans/ssp-1/profiles') {
-        return {
-          data: {
-            data: [{ id: 'profile-1', title: 'Profile One' }],
           },
         };
       }

--- a/src/views/system-security-plans/SystemSecurityPlanComplianceView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanComplianceView.vue
@@ -1,10 +1,31 @@
 <template>
   <div class="mt-6 space-y-6">
+    <div
+      v-if="!profileLoading && profileBindings.length > 1"
+      class="flex flex-wrap items-center gap-2"
+    >
+      <span class="text-sm text-zinc-600 dark:text-slate-400">Profile:</span>
+      <button
+        v-for="binding in profileBindings"
+        :key="binding.uuid"
+        type="button"
+        class="rounded-full border px-3 py-1 text-sm transition-colors"
+        :class="
+          binding.uuid === profileId
+            ? 'border-blue-600 bg-blue-600 text-white'
+            : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
+        "
+        @click="selectProfile(binding.uuid)"
+      >
+        {{ binding.title }}
+      </button>
+    </div>
+
     <template v-if="profileLoading || (profileId && isLoading)">
       <PageHeader>Loading compliance progress...</PageHeader>
     </template>
 
-    <template v-else-if="profileResolved && !profileId">
+    <template v-else-if="profileResolved && !profileBindings.length">
       <div
         class="rounded border border-dashed border-zinc-300 bg-zinc-50 dark:bg-slate-800 dark:border-slate-700 p-6 text-sm text-zinc-600 dark:text-slate-400"
       >
@@ -54,7 +75,6 @@ import ComplianceProgressPanel from '@/components/ComplianceProgressPanel.vue';
 import { useProfileCompliance } from '@/composables/useProfileCompliance';
 import { useDataApi } from '@/composables/axios';
 import type { ErrorBody, ErrorResponse } from '@/stores/types';
-import type { Profile } from '@/oscal';
 
 const route = useRoute();
 const toast = useToast();
@@ -64,10 +84,17 @@ const profileId = ref<string>('');
 const profileResolved = ref(false);
 const profileLoading = ref(false);
 
-// Load the SSP's attached profile
-const { execute: fetchProfile } = useDataApi<Profile>(null, null, {
-  immediate: false,
-});
+interface ProfileBinding {
+  uuid: string;
+  title: string;
+}
+
+const profileBindings = ref<ProfileBinding[]>([]);
+
+// Load the SSP's attached profiles (an SSP can have several)
+const { execute: fetchProfileBindings } = useDataApi<
+  Array<{ id?: string; uuid?: string; title?: string }>
+>(null, null, { immediate: false });
 
 // Once we have a profileId, load compliance data scoped to this SSP
 const {
@@ -89,17 +116,25 @@ async function loadProfileAndCompliance(currentSspId: string) {
   profileLoading.value = true;
   profileResolved.value = false;
   profileId.value = '';
+  profileBindings.value = [];
 
   try {
-    const { data } = await fetchProfile(
-      `/api/oscal/system-security-plans/${currentSspId}/profile`,
+    const { data } = await fetchProfileBindings(
+      `/api/oscal/system-security-plans/${currentSspId}/profiles`,
     );
-    const attachedProfile = data.value?.data;
-    if (!attachedProfile) {
+    const bindings = (data.value?.data || [])
+      .map((binding) => ({
+        uuid: binding.uuid || binding.id || '',
+        title: binding.title || 'Untitled Profile',
+      }))
+      .filter((binding) => binding.uuid);
+
+    profileBindings.value = bindings;
+    if (!bindings.length) {
       return;
     }
 
-    profileId.value = attachedProfile.uuid;
+    profileId.value = bindings[0].uuid;
     await loadCompliance({ includeControls: true, sspId: currentSspId });
   } catch (err) {
     const axiosErr = err as AxiosError;
@@ -108,7 +143,7 @@ async function loadProfileAndCompliance(currentSspId: string) {
       toast.add({
         severity: 'error',
         summary: 'Error loading profile',
-        detail: 'Unable to load the attached profile for this SSP.',
+        detail: 'Unable to load the attached profiles for this SSP.',
         life: 4000,
       });
     }
@@ -116,6 +151,15 @@ async function loadProfileAndCompliance(currentSspId: string) {
     profileResolved.value = true;
     profileLoading.value = false;
   }
+}
+
+async function selectProfile(nextProfileId: string) {
+  if (!nextProfileId || nextProfileId === profileId.value) {
+    return;
+  }
+
+  profileId.value = nextProfileId;
+  await loadCompliance({ includeControls: true, sspId: sspId.value });
 }
 
 watch(

--- a/src/views/system-security-plans/SystemSecurityPlanComplianceView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanComplianceView.vue
@@ -73,28 +73,23 @@ import type { AxiosError } from 'axios';
 import PageHeader from '@/components/PageHeader.vue';
 import ComplianceProgressPanel from '@/components/ComplianceProgressPanel.vue';
 import { useProfileCompliance } from '@/composables/useProfileCompliance';
-import { useDataApi } from '@/composables/axios';
 import type { ErrorBody, ErrorResponse } from '@/stores/types';
+import {
+  useSystemSecurityPlanStore,
+  type SystemSecurityPlanProfileBinding,
+} from '@/stores/system-security-plans';
+import { getErrorStatus } from '@/utils/httpErrors';
 
 const route = useRoute();
 const toast = useToast();
+const sspStore = useSystemSecurityPlanStore();
 
 const sspId = computed(() => String(route.params.id || ''));
 const profileId = ref<string>('');
 const profileResolved = ref(false);
 const profileLoading = ref(false);
 
-interface ProfileBinding {
-  uuid: string;
-  title: string;
-}
-
-const profileBindings = ref<ProfileBinding[]>([]);
-
-// Load the SSP's attached profiles (an SSP can have several)
-const { execute: fetchProfileBindings } = useDataApi<
-  Array<{ id?: string; uuid?: string; title?: string }>
->(null, null, { immediate: false });
+const profileBindings = ref<SystemSecurityPlanProfileBinding[]>([]);
 
 // Once we have a profileId, load compliance data scoped to this SSP
 const {
@@ -119,27 +114,21 @@ async function loadProfileAndCompliance(currentSspId: string) {
   profileBindings.value = [];
 
   try {
-    const { data } = await fetchProfileBindings(
-      `/api/oscal/system-security-plans/${currentSspId}/profiles`,
-    );
-    const bindings = (data.value?.data || [])
-      .map((binding) => ({
-        uuid: binding.uuid || binding.id || '',
-        title: binding.title || 'Untitled Profile',
-      }))
-      .filter((binding) => binding.uuid);
+    const { data: bindings } = await sspStore.listProfiles(currentSspId);
 
-    profileBindings.value = bindings;
-    if (!bindings.length) {
+    profileBindings.value = bindings.map((binding) => ({
+      uuid: binding.uuid,
+      title: binding.title || 'Untitled Profile',
+    }));
+    if (!profileBindings.value.length) {
       return;
     }
 
-    profileId.value = bindings[0].uuid;
+    profileId.value = profileBindings.value[0].uuid;
     await loadCompliance({ includeControls: true, sspId: currentSspId });
   } catch (err) {
-    const axiosErr = err as AxiosError;
     // 404 just means no profile attached — not an error
-    if (axiosErr.response?.status !== 404) {
+    if (getErrorStatus(err) !== 404) {
       toast.add({
         severity: 'error',
         summary: 'Error loading profile',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compliance cards now render per SSP-profile binding, enabling multiple profiles per system.
  * Added UI controls to switch the active profile and refresh compliance accordingly.
  * Risk control options now aggregate and deduplicate controls across multiple SSP profile bindings.

* **Tests**
  * Expanded mocks to support loading bindings and fetching resolved control options for specific profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->