### PR TITLE
fix: uuid fallback if insecure browser

### DIFF
--- a/src/components/poam/BackMatterResourceForm.vue
+++ b/src/components/poam/BackMatterResourceForm.vue
@@ -314,6 +314,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import type { BackMatterResource } from '@/oscal';
 import { useToast } from 'primevue/usetoast';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
@@ -396,7 +397,7 @@ onMounted(() => {
 });
 
 function generateUUID(): string {
-  return crypto.randomUUID();
+  return uuid();
 }
 
 function addDocumentId() {

--- a/src/components/poam/FindingCreateForm.vue
+++ b/src/components/poam/FindingCreateForm.vue
@@ -212,6 +212,7 @@
 
 <script setup lang="ts">
 import { reactive } from 'vue';
+import { uuid } from '@/utils/uuid';
 import type { Finding } from '@/oscal';
 import { useToast } from 'primevue/usetoast';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
@@ -315,7 +316,7 @@ async function submit() {
 
   try {
     const newFinding: Partial<Finding> = {
-      uuid: crypto.randomUUID(),
+      uuid: uuid(),
       title: formData.title,
       description: formData.description,
       target: formData.target,

--- a/src/components/poam/LocalDefinitionsForm.vue
+++ b/src/components/poam/LocalDefinitionsForm.vue
@@ -294,6 +294,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import type { POAMLocalDefinitions } from '@/oscal';
 import { useToast } from 'primevue/usetoast';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
@@ -361,7 +362,7 @@ onMounted(() => {
 });
 
 function generateUUID(): string {
-  return crypto.randomUUID();
+  return uuid();
 }
 
 function addComponent() {

--- a/src/components/poam/ObservationCreateForm.vue
+++ b/src/components/poam/ObservationCreateForm.vue
@@ -174,6 +174,7 @@
 
 <script setup lang="ts">
 import { reactive } from 'vue';
+import { uuid } from '@/utils/uuid';
 import type { Observation } from '@/oscal';
 import { useToast } from 'primevue/usetoast';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
@@ -251,7 +252,7 @@ async function submit() {
 
   try {
     const newObservation: Partial<Observation> = {
-      uuid: crypto.randomUUID(),
+      uuid: uuid(),
       title: formData.title || undefined,
       description: formData.description,
       methods: formData.methods.filter((m) => m.trim()),

--- a/src/components/poam/PoamItemCreateForm.vue
+++ b/src/components/poam/PoamItemCreateForm.vue
@@ -76,6 +76,7 @@
 
 <script setup lang="ts">
 import { reactive } from 'vue';
+import { uuid } from '@/utils/uuid';
 import type { POAMItem } from '@/oscal';
 import { useToast } from 'primevue/usetoast';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
@@ -126,7 +127,7 @@ async function submit() {
 
   try {
     const newItem: Partial<POAMItem> = {
-      uuid: crypto.randomUUID(),
+      uuid: uuid(),
       title: formData.title,
       description: formData.description,
       remarks: formData.remarks || undefined,

--- a/src/components/risk/RiskCreateForm.vue
+++ b/src/components/risk/RiskCreateForm.vue
@@ -243,6 +243,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { type Risk } from '@/oscal';
 import { useToast } from 'primevue/usetoast';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
@@ -573,7 +574,7 @@ async function submit() {
         tasks?: Array<{ title: string; orderIndex: number }>;
       };
     } = {
-      uuid: crypto.randomUUID(),
+      uuid: uuid(),
       title: formData.title,
       description: formData.description,
       statement: formData.statement,

--- a/src/components/risk/RiskMitigationsTab.vue
+++ b/src/components/risk/RiskMitigationsTab.vue
@@ -187,6 +187,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue';
+import { uuid } from '@/utils/uuid';
 import Dialog from '@/volt/Dialog.vue';
 import { useToast } from 'primevue/usetoast';
 import type { MitigatingFactor, SubjectReference, Risk } from '@/oscal';
@@ -302,7 +303,7 @@ function saveFactor() {
     editingIndex.value !== null && current[editingIndex.value]
       ? current[editingIndex.value]
       : {
-          uuid: crypto.randomUUID(),
+          uuid: uuid(),
           description: '',
         };
 

--- a/src/components/risk/RiskRemediationsTab.vue
+++ b/src/components/risk/RiskRemediationsTab.vue
@@ -143,6 +143,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue';
+import { uuid } from '@/utils/uuid';
 import Dialog from '@/volt/Dialog.vue';
 import { useToast } from 'primevue/usetoast';
 import type { Response, Risk } from '@/oscal';
@@ -255,7 +256,7 @@ function saveRemediation() {
     editingIndex.value !== null && current[editingIndex.value]
       ? current[editingIndex.value]
       : {
-          uuid: crypto.randomUUID(),
+          uuid: uuid(),
           lifecycle: working.lifecycle,
           title: working.title,
           description: working.description,

--- a/src/components/system-security-plans/ByComponentEditForm.vue
+++ b/src/components/system-security-plans/ByComponentEditForm.vue
@@ -388,6 +388,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -476,7 +477,7 @@ onMounted(() => {
 const addProvided = () => {
   if (!byComponentData.export) {
     byComponentData.export = {
-      uuid: crypto.randomUUID(),
+      uuid: uuid(),
       description: '',
       props: [],
       links: [],
@@ -488,7 +489,7 @@ const addProvided = () => {
     byComponentData.export.provided = [];
   }
   byComponentData.export.provided.push({
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
     description: '',
     props: [],
     links: [],
@@ -502,7 +503,7 @@ const removeProvided = (index: number) => {
 const addResponsibility = () => {
   if (!byComponentData.export) {
     byComponentData.export = {
-      uuid: crypto.randomUUID(),
+      uuid: uuid(),
       description: '',
       props: [],
       links: [],
@@ -514,7 +515,7 @@ const addResponsibility = () => {
     byComponentData.export.responsibilities = [];
   }
   byComponentData.export.responsibilities.push({
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
     description: '',
     props: [],
     links: [],
@@ -531,7 +532,7 @@ const addInherited = () => {
     byComponentData.inherited = [];
   }
   byComponentData.inherited.push({
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
     providedUuid: '',
     description: '',
     props: [],
@@ -549,7 +550,7 @@ const addSatisfied = () => {
     byComponentData.satisfied = [];
   }
   byComponentData.satisfied.push({
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
     responsibilityUuid: '',
     description: '',
     props: [],

--- a/src/components/system-security-plans/ImplementedRequirementCreateForm.vue
+++ b/src/components/system-security-plans/ImplementedRequirementCreateForm.vue
@@ -185,6 +185,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -234,7 +235,7 @@ onMounted(() => {
 });
 
 const generateUUID = () => {
-  requirementData.uuid = crypto.randomUUID();
+  requirementData.uuid = uuid();
 };
 
 const addProperty = () => {
@@ -243,7 +244,7 @@ const addProperty = () => {
     value: '',
     class: '',
     ns: '',
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
   });
 };
 

--- a/src/components/system-security-plans/ImplementedRequirementEditForm.vue
+++ b/src/components/system-security-plans/ImplementedRequirementEditForm.vue
@@ -177,6 +177,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -236,7 +237,7 @@ const addProperty = () => {
     value: '',
     class: '',
     ns: '',
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
   });
 };
 

--- a/src/components/system-security-plans/StatementCreateForm.vue
+++ b/src/components/system-security-plans/StatementCreateForm.vue
@@ -185,6 +185,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -236,7 +237,7 @@ onMounted(() => {
 });
 
 const generateUUID = () => {
-  statementData.uuid = crypto.randomUUID();
+  statementData.uuid = uuid();
 };
 
 const addProperty = () => {
@@ -245,7 +246,7 @@ const addProperty = () => {
     value: '',
     class: '',
     ns: '',
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
   });
 };
 

--- a/src/components/system-security-plans/StatementEditForm.vue
+++ b/src/components/system-security-plans/StatementEditForm.vue
@@ -177,6 +177,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -239,7 +240,7 @@ const addProperty = () => {
     value: '',
     class: '',
     ns: '',
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
   });
 };
 

--- a/src/components/system-security-plans/SystemImplementationComponentCreateForm.vue
+++ b/src/components/system-security-plans/SystemImplementationComponentCreateForm.vue
@@ -308,6 +308,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -502,12 +503,12 @@ onMounted(async () => {
 });
 
 const generateUUID = () => {
-  componentData.uuid = crypto.randomUUID();
+  componentData.uuid = uuid();
 };
 
 const addProtocol = () => {
   componentData.protocols!.push({
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
     title: '',
     name: '',
     portRanges: [],

--- a/src/components/system-security-plans/SystemImplementationComponentEditForm.vue
+++ b/src/components/system-security-plans/SystemImplementationComponentEditForm.vue
@@ -217,6 +217,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -282,7 +283,7 @@ onMounted(() => {
 
 const addProtocol = () => {
   componentData.protocols?.push({
-    uuid: crypto.randomUUID(),
+    uuid: uuid(),
     title: '',
     name: '',
     portRanges: [],

--- a/src/components/system-security-plans/SystemImplementationLeveragedAuthorizationCreateForm.vue
+++ b/src/components/system-security-plans/SystemImplementationLeveragedAuthorizationCreateForm.vue
@@ -171,6 +171,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -221,7 +222,7 @@ onMounted(() => {
 });
 
 const generateUUID = () => {
-  authData.uuid = crypto.randomUUID();
+  authData.uuid = uuid();
 };
 
 const addProperty = () => {

--- a/src/components/system-security-plans/SystemImplementationUserCreateForm.vue
+++ b/src/components/system-security-plans/SystemImplementationUserCreateForm.vue
@@ -196,6 +196,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue';
+import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
@@ -245,7 +246,7 @@ onMounted(() => {
 });
 
 const generateUUID = () => {
-  userData.uuid = crypto.randomUUID();
+  userData.uuid = uuid();
 };
 
 const addRoleId = () => {

--- a/src/utils/risk-detail.ts
+++ b/src/utils/risk-detail.ts
@@ -1,4 +1,5 @@
 import type { Risk, RiskLogEntry } from '@/oscal';
+import { uuid } from '@/utils/uuid';
 
 export type RiskAssociationKind = 'evidence' | 'controls' | 'components';
 
@@ -290,8 +291,7 @@ function normalizeEvent(input: unknown): RiskEventItem | null {
   if (!input || typeof input !== 'object') return null;
   const record = input as LooseRecord;
 
-  const id =
-    readString(record, ['uuid', 'id', 'eventId']) || crypto.randomUUID();
+  const id = readString(record, ['uuid', 'id', 'eventId']) || uuid();
   const type =
     readString(record, [
       'type',
@@ -408,7 +408,7 @@ function normalizeFromRiskLogEntry(entry: RiskLogEntry): RiskEventItem {
     .join(', ');
 
   return {
-    id: entry.uuid || crypto.randomUUID(),
+    id: entry.uuid || uuid(),
     type: entry.statusChange || entry.title || 'Log Event',
     timestamp: entry.start || entry.end,
     actor: actor || undefined,

--- a/src/utils/uuid.spec.ts
+++ b/src/utils/uuid.spec.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { uuid } from './uuid';
+
+const V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('uuid', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to crypto.randomUUID when available', () => {
+    const spy = vi
+      .spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValue('11111111-1111-4111-8111-111111111111');
+
+    expect(uuid()).toBe('11111111-1111-4111-8111-111111111111');
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to a v4 UUID when crypto.randomUUID is unavailable', () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
+      undefined as unknown as `${string}-${string}-${string}-${string}-${string}`,
+    );
+    // Force the typeof check to treat randomUUID as missing.
+    vi.stubGlobal('crypto', { ...globalThis.crypto, randomUUID: undefined });
+
+    const result = uuid();
+    expect(result).toMatch(V4_PATTERN);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('produces distinct values from the fallback', () => {
+    vi.stubGlobal('crypto', { randomUUID: undefined });
+
+    const values = new Set(Array.from({ length: 1000 }, () => uuid()));
+    expect(values.size).toBe(1000);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,24 @@
+/**
+ * Generate an RFC 4122 v4 UUID.
+ *
+ * Prefers the native Web Crypto `crypto.randomUUID()`, which is only available
+ * in a secure context (HTTPS, or `http://localhost`). When the app is served
+ * over plain HTTP from a non-localhost origin (e.g. behind a reverse proxy
+ * without TLS), `crypto.randomUUID` is `undefined`, so we fall back to a
+ * `Math.random()`-based generator.
+ *
+ * NOTE: the fallback is NOT cryptographically secure. It is only used to mint
+ * unique identifiers for OSCAL elements created in the browser, which do not
+ * require unpredictability. Do not use this for anything security-sensitive.
+ */
+export function uuid(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+    const random = (Math.random() * 16) | 0;
+    const value = char === 'x' ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared UUID generation approach across create/edit forms and risk/system-security plan workflows.
  * New items and nested entries now get consistent identifiers even in environments without built-in UUID support.

* **Bug Fixes**
  * Improved reliability of saving newly created records by standardizing ID generation for risks, findings, observations, POAM items, and related plan entries.

* **Tests**
  * Added coverage to verify UUID generation works in supported and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->