### PR TITLE
feat: collapse Workflow Definitions/Instances into a Workflows LHN ca…

### DIFF
--- a/src/views/LeftSideNav.vue
+++ b/src/views/LeftSideNav.vue
@@ -57,19 +57,28 @@ const links = ref<Array<NavigationItem>>([
     abbr: 'CON',
   },
   {
-    name: 'workflow:index',
-    title: 'Workflow Definitions',
-    abbr: 'WD',
-    permission: {
-      resource: RESOURCES.WORKFLOW_DEFINITION,
-      action: ACTIONS.READ,
-    },
-  },
-  {
-    name: 'workflow-instances:index',
-    title: 'Workflow Instances',
-    abbr: 'WI',
-    permission: { resource: RESOURCES.WORKFLOW_INSTANCE, action: ACTIONS.READ },
+    title: 'Workflows',
+    abbr: 'WF',
+    children: [
+      {
+        name: 'workflow:index',
+        title: 'Workflow Definitions',
+        abbr: 'WD',
+        permission: {
+          resource: RESOURCES.WORKFLOW_DEFINITION,
+          action: ACTIONS.READ,
+        },
+      },
+      {
+        name: 'workflow-instances:index',
+        title: 'Workflow Instances',
+        abbr: 'WI',
+        permission: {
+          resource: RESOURCES.WORKFLOW_INSTANCE,
+          action: ACTIONS.READ,
+        },
+      },
+    ],
   },
   {
     name: 'risks:index',


### PR DESCRIPTION
…tegory

Nests the two flat sidebar items under a single collapsible "Workflows" entry, matching the existing Implementation/Admin category pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new top-level **Workflows** navigation category.
  * Moved **Workflow Definitions** and **Workflow Instances** under this section for a more organized menu.
* **Bug Fixes**
  * Navigation visibility continues to respect existing access permissions, so only allowed items appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->