### PR TITLE
BCH-1343: Export/shared-responsibility CRUD on by-components

### DIFF
--- a/src/components/system-security-plans/ByComponentEditForm.vue
+++ b/src/components/system-security-plans/ByComponentEditForm.vue
@@ -84,87 +84,13 @@
         <div
           class="p-4 border border-ccf-300 dark:border-slate-700 rounded-md bg-gray-50 dark:bg-slate-800"
         >
-          <!-- Provided -->
-          <div class="mb-4">
-            <h4 class="text-sm font-medium dark:text-slate-300 mb-2">
-              Provided
-            </h4>
-            <div class="space-y-2">
-              <div
-                v-for="(provided, index) in byComponentData.export?.provided ||
-                []"
-                :key="provided.uuid"
-                class="p-3 border border-ccf-200 dark:border-slate-600 rounded bg-white dark:bg-slate-900"
-              >
-                <div class="flex justify-between items-start mb-2">
-                  <span class="text-xs text-gray-500 dark:text-slate-400"
-                    >UUID: {{ provided.uuid }}</span
-                  >
-                  <button
-                    type="button"
-                    @click="removeProvided(index)"
-                    class="text-red-500 hover:text-red-700 text-sm"
-                  >
-                    Remove
-                  </button>
-                </div>
-                <Textarea
-                  v-model="provided.description"
-                  placeholder="Description of what is provided"
-                  rows="2"
-                  class="w-full"
-                />
-              </div>
-              <button
-                type="button"
-                @click="addProvided"
-                class="text-sm px-3 py-1 bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-400 rounded hover:bg-green-200 dark:hover:bg-green-900/30 transition-colors"
-              >
-                Add Provided
-              </button>
-            </div>
-          </div>
-
-          <!-- Responsibilities -->
-          <div>
-            <h4 class="text-sm font-medium dark:text-slate-300 mb-2">
-              Responsibilities
-            </h4>
-            <div class="space-y-2">
-              <div
-                v-for="(responsibility, index) in byComponentData.export
-                  ?.responsibilities || []"
-                :key="responsibility.uuid"
-                class="p-3 border border-ccf-200 dark:border-slate-600 rounded bg-white dark:bg-slate-900"
-              >
-                <div class="flex justify-between items-start mb-2">
-                  <span class="text-xs text-gray-500 dark:text-slate-400"
-                    >UUID: {{ responsibility.uuid }}</span
-                  >
-                  <button
-                    type="button"
-                    @click="removeResponsibility(index)"
-                    class="text-red-500 hover:text-red-700 text-sm"
-                  >
-                    Remove
-                  </button>
-                </div>
-                <Textarea
-                  v-model="responsibility.description"
-                  placeholder="Description of responsibility"
-                  rows="2"
-                  class="w-full"
-                />
-              </div>
-              <button
-                type="button"
-                @click="addResponsibility"
-                class="text-sm px-3 py-1 bg-orange-100 dark:bg-orange-900/20 text-orange-700 dark:text-orange-400 rounded hover:bg-orange-200 dark:hover:bg-orange-900/30 transition-colors"
-              >
-                Add Responsibility
-              </button>
-            </div>
-          </div>
+          <ByComponentExportEditor
+            :ssp-id="props.sspId"
+            :req-id="props.requirement.uuid"
+            :stmt-id="props.statement?.uuid"
+            :by-component-id="props.byComponent.uuid"
+            v-model="byComponentData.export"
+          />
         </div>
       </div>
 
@@ -392,6 +318,7 @@ import { uuid } from '@/utils/uuid';
 import { useToast } from 'primevue/usetoast';
 import InputText from '@/volt/InputText.vue';
 import Textarea from '@/volt/Textarea.vue';
+import ByComponentExportEditor from './ByComponentExportEditor.vue';
 import type { ByComponent, Statement, ImplementedRequirement } from '@/oscal';
 import { useDataApi, decamelizeKeys } from '@/composables/axios';
 import type { AxiosError } from 'axios';
@@ -472,59 +399,6 @@ onMounted(() => {
     responsibleRoles: [...(props.byComponent.responsibleRoles || [])],
   });
 });
-
-// Export functions
-const addProvided = () => {
-  if (!byComponentData.export) {
-    byComponentData.export = {
-      uuid: uuid(),
-      description: '',
-      props: [],
-      links: [],
-      provided: [],
-      responsibilities: [],
-    };
-  }
-  if (!byComponentData.export.provided) {
-    byComponentData.export.provided = [];
-  }
-  byComponentData.export.provided.push({
-    uuid: uuid(),
-    description: '',
-    props: [],
-    links: [],
-  });
-};
-
-const removeProvided = (index: number) => {
-  byComponentData.export?.provided?.splice(index, 1);
-};
-
-const addResponsibility = () => {
-  if (!byComponentData.export) {
-    byComponentData.export = {
-      uuid: uuid(),
-      description: '',
-      props: [],
-      links: [],
-      provided: [],
-      responsibilities: [],
-    };
-  }
-  if (!byComponentData.export.responsibilities) {
-    byComponentData.export.responsibilities = [];
-  }
-  byComponentData.export.responsibilities.push({
-    uuid: uuid(),
-    description: '',
-    props: [],
-    links: [],
-  });
-};
-
-const removeResponsibility = (index: number) => {
-  byComponentData.export?.responsibilities?.splice(index, 1);
-};
 
 // Inherited functions
 const addInherited = () => {
@@ -618,8 +492,12 @@ const updateByComponent = async () => {
   }
 
   try {
+    // Export/Provided/Responsibilities are persisted independently by
+    // ByComponentExportEditor via BCH-1336's dedicated endpoints, so they're
+    // omitted here to avoid the two save paths racing or clobbering each
+    // other's writes.
     await updateByComponentApi({
-      data: byComponentData,
+      data: { ...byComponentData, export: undefined },
     });
 
     toast.add({
@@ -629,7 +507,13 @@ const updateByComponent = async () => {
       life: 3000,
     });
 
-    emit('saved', updatedByComponent.value!);
+    // The PUT response reflects the request body, which omitted `export`, so
+    // restore it from the locally-maintained copy (kept live by
+    // ByComponentExportEditor's v-model) rather than the response.
+    emit('saved', {
+      ...updatedByComponent.value!,
+      export: byComponentData.export,
+    });
   } catch (error) {
     const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
     const errorMessage =

--- a/src/components/system-security-plans/ByComponentExportEditor.vue
+++ b/src/components/system-security-plans/ByComponentExportEditor.vue
@@ -1,0 +1,677 @@
+<template>
+  <div class="space-y-6">
+    <!-- Provided -->
+    <div>
+      <div class="flex items-center justify-between mb-2">
+        <h4 class="text-sm font-medium dark:text-slate-300">Provided</h4>
+        <PermissionGate :resource="RESOURCES.SSP" :action="ACTIONS.UPDATE">
+          <SecondaryButton
+            v-if="!draftProvided"
+            type="button"
+            size="small"
+            @click="startAddProvided"
+          >
+            Add Provided
+          </SecondaryButton>
+        </PermissionGate>
+      </div>
+
+      <div
+        v-if="!providedEntries.length && !draftProvided"
+        class="text-sm text-gray-500 dark:text-slate-400 py-2"
+      >
+        No provided entries yet.
+      </div>
+
+      <div class="space-y-2">
+        <div
+          v-for="entry in providedEntries"
+          :key="entry.uuid"
+          class="p-3 border border-ccf-200 dark:border-slate-600 rounded bg-white dark:bg-slate-900"
+        >
+          <template
+            v-if="editingProvidedUuid === entry.uuid && editProvidedBuffer"
+          >
+            <ByComponentExportEntryFields
+              v-model:description="editProvidedBuffer.description"
+              v-model:responsible-roles="editProvidedBuffer.responsibleRoles"
+              description-placeholder="Description of what is provided"
+            />
+            <div class="flex justify-end gap-2 mt-2">
+              <SecondaryButton
+                type="button"
+                size="small"
+                @click="cancelEditProvided"
+              >
+                Cancel
+              </SecondaryButton>
+              <PrimaryButton
+                type="button"
+                size="small"
+                :disabled="savingProvidedUuid === entry.uuid"
+                @click="saveEditProvided(entry)"
+              >
+                Save
+              </PrimaryButton>
+            </div>
+          </template>
+          <template v-else>
+            <div class="flex justify-between items-start mb-1">
+              <p class="text-sm dark:text-slate-300 whitespace-pre-wrap">
+                {{ entry.description || '(no description)' }}
+              </p>
+              <PermissionGate
+                :resource="RESOURCES.SSP"
+                :action="ACTIONS.UPDATE"
+              >
+                <div class="flex gap-2 shrink-0 ml-2">
+                  <button
+                    type="button"
+                    class="text-blue-500 hover:text-blue-700 text-sm"
+                    @click="startEditProvided(entry)"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    class="text-red-500 hover:text-red-700 text-sm"
+                    @click="removeProvided(entry)"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </PermissionGate>
+            </div>
+            <div
+              v-if="entry.responsibleRoles?.length"
+              class="text-xs text-gray-500 dark:text-slate-400"
+            >
+              Roles:
+              {{ entry.responsibleRoles.map((r) => r.roleId).join(', ') }}
+            </div>
+          </template>
+        </div>
+
+        <div
+          v-if="draftProvided"
+          class="p-3 border border-ccf-200 dark:border-slate-600 rounded bg-white dark:bg-slate-900"
+        >
+          <ByComponentExportEntryFields
+            v-model:description="draftProvided.description"
+            v-model:responsible-roles="draftProvided.responsibleRoles"
+            description-placeholder="Description of what is provided"
+          />
+          <div class="flex justify-end gap-2 mt-2">
+            <SecondaryButton
+              type="button"
+              size="small"
+              @click="cancelAddProvided"
+            >
+              Cancel
+            </SecondaryButton>
+            <PrimaryButton
+              type="button"
+              size="small"
+              :disabled="savingNewProvided"
+              @click="saveNewProvided"
+            >
+              Save
+            </PrimaryButton>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Responsibilities -->
+    <div>
+      <div class="flex items-center justify-between mb-2">
+        <h4 class="text-sm font-medium dark:text-slate-300">
+          Responsibilities
+        </h4>
+        <PermissionGate :resource="RESOURCES.SSP" :action="ACTIONS.UPDATE">
+          <SecondaryButton
+            v-if="!draftResponsibility"
+            type="button"
+            size="small"
+            @click="startAddResponsibility"
+          >
+            Add Responsibility
+          </SecondaryButton>
+        </PermissionGate>
+      </div>
+
+      <div
+        v-if="!responsibilityEntries.length && !draftResponsibility"
+        class="text-sm text-gray-500 dark:text-slate-400 py-2"
+      >
+        No responsibility entries yet.
+      </div>
+
+      <div class="space-y-2">
+        <div
+          v-for="entry in responsibilityEntries"
+          :key="entry.uuid"
+          class="p-3 border border-ccf-200 dark:border-slate-600 rounded bg-white dark:bg-slate-900"
+        >
+          <template
+            v-if="
+              editingResponsibilityUuid === entry.uuid &&
+              editResponsibilityBuffer
+            "
+          >
+            <div class="mb-2">
+              <Label :for="`provided-select-${entry.uuid}`" required>
+                Provided
+              </Label>
+              <Select
+                :id="`provided-select-${entry.uuid}`"
+                v-model="editResponsibilityBuffer.providedUuid"
+                :options="providedEntries"
+                option-label="description"
+                option-value="uuid"
+                placeholder="Select a provided entry"
+                class="w-full"
+                @update:model-value="editResponsibilityError = ''"
+              />
+              <Message
+                v-if="editResponsibilityError"
+                severity="error"
+                class="mt-1"
+              >
+                {{ editResponsibilityError }}
+              </Message>
+            </div>
+            <ByComponentExportEntryFields
+              v-model:description="editResponsibilityBuffer.description"
+              v-model:responsible-roles="
+                editResponsibilityBuffer.responsibleRoles
+              "
+              description-placeholder="Description of responsibility"
+            />
+            <div class="flex justify-end gap-2 mt-2">
+              <SecondaryButton
+                type="button"
+                size="small"
+                @click="cancelEditResponsibility"
+              >
+                Cancel
+              </SecondaryButton>
+              <PrimaryButton
+                type="button"
+                size="small"
+                :disabled="savingResponsibilityUuid === entry.uuid"
+                @click="saveEditResponsibility(entry)"
+              >
+                Save
+              </PrimaryButton>
+            </div>
+          </template>
+          <template v-else>
+            <div class="flex justify-between items-start mb-1">
+              <div>
+                <p class="text-sm dark:text-slate-300 whitespace-pre-wrap">
+                  {{ entry.description || '(no description)' }}
+                </p>
+                <div class="text-xs text-gray-500 dark:text-slate-400">
+                  Provided: {{ providedDescription(entry.providedUuid) }}
+                </div>
+              </div>
+              <PermissionGate
+                :resource="RESOURCES.SSP"
+                :action="ACTIONS.UPDATE"
+              >
+                <div class="flex gap-2 shrink-0 ml-2">
+                  <button
+                    type="button"
+                    class="text-blue-500 hover:text-blue-700 text-sm"
+                    @click="startEditResponsibility(entry)"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    class="text-red-500 hover:text-red-700 text-sm"
+                    @click="removeResponsibility(entry)"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </PermissionGate>
+            </div>
+            <div
+              v-if="entry.responsibleRoles?.length"
+              class="text-xs text-gray-500 dark:text-slate-400"
+            >
+              Roles:
+              {{ entry.responsibleRoles.map((r) => r.roleId).join(', ') }}
+            </div>
+          </template>
+        </div>
+
+        <div
+          v-if="draftResponsibility"
+          class="p-3 border border-ccf-200 dark:border-slate-600 rounded bg-white dark:bg-slate-900"
+        >
+          <div class="mb-2">
+            <Label for="new-responsibility-provided" required>Provided</Label>
+            <Select
+              id="new-responsibility-provided"
+              v-model="draftResponsibility.providedUuid"
+              :options="providedEntries"
+              option-label="description"
+              option-value="uuid"
+              placeholder="Select a provided entry"
+              class="w-full"
+              @update:model-value="newResponsibilityError = ''"
+            />
+            <Message
+              v-if="newResponsibilityError"
+              severity="error"
+              class="mt-1"
+            >
+              {{ newResponsibilityError }}
+            </Message>
+          </div>
+          <ByComponentExportEntryFields
+            v-model:description="draftResponsibility.description"
+            v-model:responsible-roles="draftResponsibility.responsibleRoles"
+            description-placeholder="Description of responsibility"
+          />
+          <div class="flex justify-end gap-2 mt-2">
+            <SecondaryButton
+              type="button"
+              size="small"
+              @click="cancelAddResponsibility"
+            >
+              Cancel
+            </SecondaryButton>
+            <PrimaryButton
+              type="button"
+              size="small"
+              :disabled="savingNewResponsibility"
+              @click="saveNewResponsibility"
+            >
+              Save
+            </PrimaryButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import type { AxiosError } from 'axios';
+import PrimaryButton from '@/volt/PrimaryButton.vue';
+import SecondaryButton from '@/volt/SecondaryButton.vue';
+import Select from '@/volt/Select.vue';
+import Label from '@/volt/Label.vue';
+import Message from '@/volt/Message.vue';
+import PermissionGate from '@/components/auth/PermissionGate.vue';
+import ByComponentExportEntryFields from './ByComponentExportEntryFields.vue';
+import { RESOURCES, ACTIONS } from '@/constants/permissions';
+import { useAuthenticatedInstance, decamelizeKeys } from '@/composables/axios';
+import { uuid } from '@/utils/uuid';
+import type {
+  ByComponentExport,
+  ByComponentExportProvided,
+  ByComponentExportResponsibility,
+  ResponsibleRole,
+} from '@/oscal';
+import type { DataResponse, ErrorBody, ErrorResponse } from '@/stores/types';
+
+const props = defineProps<{
+  sspId: string;
+  reqId: string;
+  stmtId?: string;
+  byComponentId: string;
+  modelValue: ByComponentExport | undefined;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: ByComponentExport | undefined];
+}>();
+
+const toast = useToast();
+const axiosInstance = useAuthenticatedInstance();
+const requestConfig = { transformRequest: [decamelizeKeys] };
+
+const localExport = ref<ByComponentExport | undefined>(
+  props.modelValue ? cloneExport(props.modelValue) : undefined,
+);
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    localExport.value = value ? cloneExport(value) : undefined;
+  },
+);
+
+type WithRoles<T> = T & { responsibleRoles: ResponsibleRole[] };
+
+function withRoles<T extends { responsibleRoles?: ResponsibleRole[] }>(
+  entry: T,
+): WithRoles<T> {
+  return { ...entry, responsibleRoles: entry.responsibleRoles ?? [] };
+}
+
+function cloneExport(value: ByComponentExport): ByComponentExport {
+  const cloned = JSON.parse(JSON.stringify(value)) as ByComponentExport;
+  cloned.provided = (cloned.provided ?? []).map(withRoles);
+  cloned.responsibilities = (cloned.responsibilities ?? []).map(withRoles);
+  return cloned;
+}
+
+const providedEntries = computed(() => localExport.value?.provided ?? []);
+const responsibilityEntries = computed(
+  () => localExport.value?.responsibilities ?? [],
+);
+
+function providedDescription(providedUuid: string | undefined): string {
+  if (!providedUuid) return '(none)';
+  const match = providedEntries.value.find((p) => p.uuid === providedUuid);
+  return match?.description || providedUuid;
+}
+
+const baseUrl = computed(() => {
+  const base = props.stmtId
+    ? `/api/oscal/system-security-plans/${props.sspId}/control-implementation/implemented-requirements/${props.reqId}/statements/${props.stmtId}/by-components/${props.byComponentId}`
+    : `/api/oscal/system-security-plans/${props.sspId}/control-implementation/implemented-requirements/${props.reqId}/by-components/${props.byComponentId}`;
+  return `${base}/export`;
+});
+const providedUrl = computed(() => `${baseUrl.value}/provided`);
+const responsibilitiesUrl = computed(() => `${baseUrl.value}/responsibilities`);
+
+function errorMessage(error: unknown, fallback: string): string {
+  const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+  return (
+    errorResponse.response?.data?.errors?.body ||
+    errorResponse.message ||
+    fallback
+  );
+}
+
+// The dedicated Provided/Responsibility endpoints 404 until an Export row exists, so the
+// first add of either must create the Export first.
+async function ensureExport(): Promise<void> {
+  if (localExport.value) return;
+  const response = await axiosInstance.post<DataResponse<ByComponentExport>>(
+    baseUrl.value,
+    { description: '', remarks: '' },
+    requestConfig,
+  );
+  localExport.value = {
+    ...response.data.data,
+    provided: response.data.data.provided ?? [],
+    responsibilities: response.data.data.responsibilities ?? [],
+  };
+  emit('update:modelValue', localExport.value);
+}
+
+// ---- Provided ----
+
+const draftProvided = ref<WithRoles<ByComponentExportProvided> | null>(null);
+const savingNewProvided = ref(false);
+const editingProvidedUuid = ref<string | null>(null);
+const editProvidedBuffer = ref<WithRoles<ByComponentExportProvided> | null>(
+  null,
+);
+const savingProvidedUuid = ref<string | null>(null);
+
+function startAddProvided() {
+  draftProvided.value = {
+    uuid: uuid(),
+    description: '',
+    responsibleRoles: [],
+  };
+}
+
+function cancelAddProvided() {
+  draftProvided.value = null;
+}
+
+async function saveNewProvided() {
+  if (!draftProvided.value) return;
+  savingNewProvided.value = true;
+  try {
+    await ensureExport();
+    const response = await axiosInstance.post<
+      DataResponse<ByComponentExportProvided>
+    >(providedUrl.value, draftProvided.value, requestConfig);
+    localExport.value!.provided = [
+      ...(localExport.value!.provided ?? []),
+      withRoles(response.data.data),
+    ];
+    emit('update:modelValue', localExport.value);
+    draftProvided.value = null;
+    toast.add({
+      severity: 'success',
+      summary: 'Provided entry added.',
+      life: 3000,
+    });
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: errorMessage(error, 'Failed to add provided entry.'),
+      life: 5000,
+    });
+  } finally {
+    savingNewProvided.value = false;
+  }
+}
+
+function startEditProvided(entry: ByComponentExportProvided) {
+  editingProvidedUuid.value = entry.uuid;
+  editProvidedBuffer.value = withRoles(
+    JSON.parse(JSON.stringify(entry)) as ByComponentExportProvided,
+  );
+}
+
+function cancelEditProvided() {
+  editingProvidedUuid.value = null;
+  editProvidedBuffer.value = null;
+}
+
+async function saveEditProvided(entry: ByComponentExportProvided) {
+  if (!editProvidedBuffer.value) return;
+  savingProvidedUuid.value = entry.uuid;
+  try {
+    const response = await axiosInstance.put<
+      DataResponse<ByComponentExportProvided>
+    >(
+      `${providedUrl.value}/${entry.uuid}`,
+      editProvidedBuffer.value,
+      requestConfig,
+    );
+    const index = (localExport.value!.provided ?? []).findIndex(
+      (p) => p.uuid === entry.uuid,
+    );
+    if (index !== -1) {
+      localExport.value!.provided![index] = withRoles(response.data.data);
+    }
+    emit('update:modelValue', localExport.value);
+    cancelEditProvided();
+    toast.add({
+      severity: 'success',
+      summary: 'Provided entry updated.',
+      life: 3000,
+    });
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: errorMessage(error, 'Failed to update provided entry.'),
+      life: 5000,
+    });
+  } finally {
+    savingProvidedUuid.value = null;
+  }
+}
+
+async function removeProvided(entry: ByComponentExportProvided) {
+  try {
+    await axiosInstance.delete(`${providedUrl.value}/${entry.uuid}`);
+    localExport.value!.provided = (localExport.value!.provided ?? []).filter(
+      (p) => p.uuid !== entry.uuid,
+    );
+    emit('update:modelValue', localExport.value);
+    toast.add({
+      severity: 'success',
+      summary: 'Provided entry removed.',
+      life: 3000,
+    });
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: errorMessage(error, 'Failed to remove provided entry.'),
+      life: 5000,
+    });
+  }
+}
+
+// ---- Responsibilities ----
+
+const draftResponsibility =
+  ref<WithRoles<ByComponentExportResponsibility> | null>(null);
+const newResponsibilityError = ref('');
+const savingNewResponsibility = ref(false);
+const editingResponsibilityUuid = ref<string | null>(null);
+const editResponsibilityBuffer =
+  ref<WithRoles<ByComponentExportResponsibility> | null>(null);
+const editResponsibilityError = ref('');
+const savingResponsibilityUuid = ref<string | null>(null);
+
+function startAddResponsibility() {
+  draftResponsibility.value = {
+    uuid: uuid(),
+    description: '',
+    providedUuid: '',
+    responsibleRoles: [],
+  };
+  newResponsibilityError.value = '';
+}
+
+function cancelAddResponsibility() {
+  draftResponsibility.value = null;
+  newResponsibilityError.value = '';
+}
+
+async function saveNewResponsibility() {
+  if (!draftResponsibility.value) return;
+  if (!draftResponsibility.value.providedUuid) {
+    newResponsibilityError.value =
+      'Select a provided entry before saving this responsibility.';
+    return;
+  }
+  savingNewResponsibility.value = true;
+  try {
+    await ensureExport();
+    const response = await axiosInstance.post<
+      DataResponse<ByComponentExportResponsibility>
+    >(responsibilitiesUrl.value, draftResponsibility.value, requestConfig);
+    localExport.value!.responsibilities = [
+      ...(localExport.value!.responsibilities ?? []),
+      withRoles(response.data.data),
+    ];
+    emit('update:modelValue', localExport.value);
+    draftResponsibility.value = null;
+    toast.add({
+      severity: 'success',
+      summary: 'Responsibility entry added.',
+      life: 3000,
+    });
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: errorMessage(error, 'Failed to add responsibility entry.'),
+      life: 5000,
+    });
+  } finally {
+    savingNewResponsibility.value = false;
+  }
+}
+
+function startEditResponsibility(entry: ByComponentExportResponsibility) {
+  editingResponsibilityUuid.value = entry.uuid;
+  editResponsibilityBuffer.value = withRoles(
+    JSON.parse(JSON.stringify(entry)) as ByComponentExportResponsibility,
+  );
+  editResponsibilityError.value = '';
+}
+
+function cancelEditResponsibility() {
+  editingResponsibilityUuid.value = null;
+  editResponsibilityBuffer.value = null;
+  editResponsibilityError.value = '';
+}
+
+async function saveEditResponsibility(entry: ByComponentExportResponsibility) {
+  if (!editResponsibilityBuffer.value) return;
+  if (!editResponsibilityBuffer.value.providedUuid) {
+    editResponsibilityError.value =
+      'Select a provided entry before saving this responsibility.';
+    return;
+  }
+  savingResponsibilityUuid.value = entry.uuid;
+  try {
+    const response = await axiosInstance.put<
+      DataResponse<ByComponentExportResponsibility>
+    >(
+      `${responsibilitiesUrl.value}/${entry.uuid}`,
+      editResponsibilityBuffer.value,
+      requestConfig,
+    );
+    const index = (localExport.value!.responsibilities ?? []).findIndex(
+      (r) => r.uuid === entry.uuid,
+    );
+    if (index !== -1) {
+      localExport.value!.responsibilities![index] = withRoles(
+        response.data.data,
+      );
+    }
+    emit('update:modelValue', localExport.value);
+    cancelEditResponsibility();
+    toast.add({
+      severity: 'success',
+      summary: 'Responsibility entry updated.',
+      life: 3000,
+    });
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: errorMessage(error, 'Failed to update responsibility entry.'),
+      life: 5000,
+    });
+  } finally {
+    savingResponsibilityUuid.value = null;
+  }
+}
+
+async function removeResponsibility(entry: ByComponentExportResponsibility) {
+  try {
+    await axiosInstance.delete(`${responsibilitiesUrl.value}/${entry.uuid}`);
+    localExport.value!.responsibilities = (
+      localExport.value!.responsibilities ?? []
+    ).filter((r) => r.uuid !== entry.uuid);
+    emit('update:modelValue', localExport.value);
+    toast.add({
+      severity: 'success',
+      summary: 'Responsibility entry removed.',
+      life: 3000,
+    });
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: errorMessage(error, 'Failed to remove responsibility entry.'),
+      life: 5000,
+    });
+  }
+}
+</script>

--- a/src/components/system-security-plans/ByComponentExportEntryFields.vue
+++ b/src/components/system-security-plans/ByComponentExportEntryFields.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <Textarea
+      v-model="description"
+      :placeholder="descriptionPlaceholder"
+      rows="2"
+      class="w-full"
+    />
+    <div class="mt-2">
+      <div class="text-xs font-medium text-gray-500 dark:text-slate-400 mb-1">
+        Responsible Roles
+      </div>
+      <div class="space-y-1">
+        <div
+          v-for="(role, index) in responsibleRoles"
+          :key="index"
+          class="flex gap-2 items-center"
+        >
+          <InputText
+            v-model="role.roleId"
+            placeholder="Role ID"
+            class="w-1/3"
+          />
+          <InputText
+            :model-value="role.partyUuids?.join(', ')"
+            @update:model-value="(value) => setPartyUuids(index, String(value))"
+            placeholder="Party UUIDs (comma-separated)"
+            class="flex-1"
+          />
+          <button
+            type="button"
+            class="text-red-500 hover:text-red-700 text-sm"
+            @click="removeRole(index)"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="text-xs px-2 py-1 mt-1 bg-gray-200 dark:bg-slate-700 text-gray-700 dark:text-slate-300 rounded hover:bg-gray-300 dark:hover:bg-slate-600 transition-colors"
+        @click="addRole"
+      >
+        Add Role
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import InputText from '@/volt/InputText.vue';
+import Textarea from '@/volt/Textarea.vue';
+import type { ResponsibleRole } from '@/oscal';
+
+defineProps<{
+  descriptionPlaceholder?: string;
+}>();
+
+const description = defineModel<string>('description', { required: true });
+const responsibleRoles = defineModel<ResponsibleRole[]>('responsibleRoles', {
+  required: true,
+});
+
+function addRole() {
+  responsibleRoles.value.push({ roleId: '', partyUuids: [] });
+}
+
+function removeRole(index: number) {
+  responsibleRoles.value.splice(index, 1);
+}
+
+function setPartyUuids(index: number, value: string) {
+  const role = responsibleRoles.value[index];
+  if (!role) return;
+  role.partyUuids = value
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
+</script>

--- a/src/components/system-security-plans/__tests__/ByComponentExportEditor.spec.ts
+++ b/src/components/system-security-plans/__tests__/ByComponentExportEditor.spec.ts
@@ -56,7 +56,10 @@ const stubs = {
     props: ['description', 'responsibleRoles'],
     emits: ['update:description', 'update:responsibleRoles'],
     template:
-      '<textarea :value="description" @input="$emit(\'update:description\', $event.target.value)" />',
+      '<div>' +
+      '<textarea :value="description" @input="$emit(\'update:description\', $event.target.value)" />' +
+      '<button type="button" @click="$emit(\'update:responsibleRoles\', [...responsibleRoles, { roleId: \'owner\', partyUuids: [] }])">Add Role</button>' +
+      '</div>',
   },
 };
 
@@ -73,6 +76,12 @@ function mountEditor(props: {
     },
     global: { stubs },
   });
+}
+
+function findButton(wrapper: ReturnType<typeof mountEditor>, text: string) {
+  const button = wrapper.findAll('button').find((b) => b.text() === text);
+  if (!button) throw new Error(`Button with text "${text}" not found`);
+  return button;
 }
 
 describe('ByComponentExportEditor', () => {
@@ -106,12 +115,9 @@ describe('ByComponentExportEditor', () => {
       });
 
     const wrapper = mountEditor({ modelValue: undefined });
-    await wrapper.find('button').trigger('click'); // Add Provided
+    await findButton(wrapper, 'Add Provided').trigger('click');
     await wrapper.find('textarea').setValue('We provide X');
-    const saveButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Save')!;
-    await saveButton.trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
     await flushPromises();
 
     expect(postMock).toHaveBeenNthCalledWith(
@@ -126,7 +132,45 @@ describe('ByComponentExportEditor', () => {
       expect.objectContaining({ description: 'We provide X' }),
       expect.anything(),
     );
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeTruthy();
+    const lastPayload = emitted![emitted!.length - 1][0] as ByComponentExport;
+    expect(lastPayload.provided).toContainEqual(
+      expect.objectContaining({ uuid: 'p-1', description: 'We provide X' }),
+    );
+  });
+
+  it('includes responsible roles when creating a provided entry', async () => {
+    postMock
+      .mockResolvedValueOnce({
+        data: { data: { description: '', remarks: '' } },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            uuid: 'p-1',
+            description: 'We provide X',
+            responsibleRoles: [{ roleId: 'owner', partyUuids: [] }],
+          },
+        },
+      });
+
+    const wrapper = mountEditor({ modelValue: undefined });
+    await findButton(wrapper, 'Add Provided').trigger('click');
+    await wrapper.find('textarea').setValue('We provide X');
+    await findButton(wrapper, 'Add Role').trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/provided',
+      expect.objectContaining({
+        responsibleRoles: [{ roleId: 'owner', partyUuids: [] }],
+      }),
+      expect.anything(),
+    );
   });
 
   it('uses the statement-level route when stmtId is set', async () => {
@@ -137,12 +181,9 @@ describe('ByComponentExportEditor', () => {
       });
 
     const wrapper = mountEditor({ modelValue: undefined, stmtId: 'stmt-1' });
-    await wrapper.find('button').trigger('click');
+    await findButton(wrapper, 'Add Provided').trigger('click');
     await wrapper.find('textarea').setValue('x');
-    const saveButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Save')!;
-    await saveButton.trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
     await flushPromises();
 
     expect(postMock.mock.calls[0][0]).toBe(
@@ -166,15 +207,9 @@ describe('ByComponentExportEditor', () => {
     });
 
     const wrapper = mountEditor({ modelValue });
-    const editButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Edit')!;
-    await editButton.trigger('click');
+    await findButton(wrapper, 'Edit').trigger('click');
     await wrapper.find('textarea').setValue('Updated');
-    const saveButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Save')!;
-    await saveButton.trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
     await flushPromises();
 
     expect(putMock).toHaveBeenCalledWith(
@@ -194,14 +229,80 @@ describe('ByComponentExportEditor', () => {
       responsibilities: [],
     };
     const wrapper = mountEditor({ modelValue });
-    const removeButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Remove')!;
-    await removeButton.trigger('click');
+    await findButton(wrapper, 'Remove').trigger('click');
     await flushPromises();
 
     expect(deleteMock).toHaveBeenCalledWith(
       '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/provided/p-1',
+    );
+  });
+
+  it('discards draft changes and issues no request when adding a provided entry is cancelled', async () => {
+    const wrapper = mountEditor({ modelValue: undefined });
+    await findButton(wrapper, 'Add Provided').trigger('click');
+    await wrapper.find('textarea').setValue('Discarded description');
+    await findButton(wrapper, 'Cancel').trigger('click');
+    await flushPromises();
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(wrapper.find('textarea').exists()).toBe(false);
+    expect(
+      wrapper.findAll('button').some((b) => b.text() === 'Add Provided'),
+    ).toBe(true);
+  });
+
+  it('discards edits to an existing provided entry when Cancel is clicked', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Original', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    const wrapper = mountEditor({ modelValue });
+    await findButton(wrapper, 'Edit').trigger('click');
+    await wrapper.find('textarea').setValue('Changed but discarded');
+    await findButton(wrapper, 'Cancel').trigger('click');
+    await flushPromises();
+
+    expect(putMock).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Original');
+    expect(wrapper.text()).not.toContain('Changed but discarded');
+  });
+
+  it('shows an error toast when creating a provided entry fails', async () => {
+    postMock
+      .mockResolvedValueOnce({ data: { data: { description: '' } } })
+      .mockRejectedValueOnce(new Error('network down'));
+
+    const wrapper = mountEditor({ modelValue: undefined });
+    await findButton(wrapper, 'Add Provided').trigger('click');
+    await wrapper.find('textarea').setValue('We provide X');
+    await findButton(wrapper, 'Save').trigger('click');
+    await flushPromises();
+
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' }),
+    );
+  });
+
+  it('shows an error toast when removing a provided entry fails', async () => {
+    deleteMock.mockRejectedValueOnce(new Error('network down'));
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Original', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    const wrapper = mountEditor({ modelValue });
+    await findButton(wrapper, 'Remove').trigger('click');
+    await flushPromises();
+
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' }),
     );
   });
 
@@ -215,14 +316,8 @@ describe('ByComponentExportEditor', () => {
       responsibilities: [],
     };
     const wrapper = mountEditor({ modelValue });
-    const addResponsibilityButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Add Responsibility')!;
-    await addResponsibilityButton.trigger('click');
-    const saveButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Save')!;
-    await saveButton.trigger('click');
+    await findButton(wrapper, 'Add Responsibility').trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
     await flushPromises();
 
     expect(postMock).not.toHaveBeenCalled();
@@ -252,22 +347,115 @@ describe('ByComponentExportEditor', () => {
     });
 
     const wrapper = mountEditor({ modelValue });
-    const addResponsibilityButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Add Responsibility')!;
-    await addResponsibilityButton.trigger('click');
+    await findButton(wrapper, 'Add Responsibility').trigger('click');
     await wrapper.find('select').setValue('p-1');
     await wrapper.find('textarea').setValue('My responsibility');
-    const saveButton = wrapper
-      .findAll('button')
-      .find((b) => b.text() === 'Save')!;
-    await saveButton.trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
     await flushPromises();
 
     expect(postMock).toHaveBeenCalledWith(
       '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/responsibilities',
       expect.objectContaining({ providedUuid: 'p-1' }),
       expect.anything(),
+    );
+  });
+
+  it('includes responsible roles when creating a responsibility entry', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Provided A', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    postMock.mockResolvedValueOnce({
+      data: {
+        data: {
+          uuid: 'r-1',
+          description: 'My responsibility',
+          providedUuid: 'p-1',
+          responsibleRoles: [{ roleId: 'owner', partyUuids: [] }],
+        },
+      },
+    });
+
+    const wrapper = mountEditor({ modelValue });
+    await findButton(wrapper, 'Add Responsibility').trigger('click');
+    await wrapper.find('select').setValue('p-1');
+    await wrapper.find('textarea').setValue('My responsibility');
+    await findButton(wrapper, 'Add Role').trigger('click');
+    await findButton(wrapper, 'Save').trigger('click');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/responsibilities',
+      expect.objectContaining({
+        providedUuid: 'p-1',
+        responsibleRoles: [{ roleId: 'owner', partyUuids: [] }],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('edits an existing responsibility entry via PUT', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [],
+      responsibilities: [
+        {
+          uuid: 'r-1',
+          description: 'Original',
+          providedUuid: 'p-1',
+          responsibleRoles: [],
+        },
+      ],
+    };
+    putMock.mockResolvedValueOnce({
+      data: {
+        data: {
+          uuid: 'r-1',
+          description: 'Updated',
+          providedUuid: 'p-1',
+          responsibleRoles: [],
+        },
+      },
+    });
+
+    const wrapper = mountEditor({ modelValue });
+    await findButton(wrapper, 'Edit').trigger('click');
+    await wrapper.find('textarea').setValue('Updated');
+    await findButton(wrapper, 'Save').trigger('click');
+    await flushPromises();
+
+    expect(putMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/responsibilities/r-1',
+      expect.objectContaining({ description: 'Updated' }),
+      expect.anything(),
+    );
+  });
+
+  it('removes a responsibility entry via DELETE', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [],
+      responsibilities: [
+        {
+          uuid: 'r-1',
+          description: 'Original',
+          providedUuid: 'p-1',
+          responsibleRoles: [],
+        },
+      ],
+    };
+    const wrapper = mountEditor({ modelValue });
+    await findButton(wrapper, 'Remove').trigger('click');
+    await flushPromises();
+
+    expect(deleteMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/responsibilities/r-1',
     );
   });
 

--- a/src/components/system-security-plans/__tests__/ByComponentExportEditor.spec.ts
+++ b/src/components/system-security-plans/__tests__/ByComponentExportEditor.spec.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import ByComponentExportEditor from '../ByComponentExportEditor.vue';
+import type { ByComponentExport } from '@/oscal';
+
+const { postMock, putMock, deleteMock, toastAddMock, permState } = vi.hoisted(
+  () => ({
+    postMock: vi.fn(),
+    putMock: vi.fn(),
+    deleteMock: vi.fn(),
+    toastAddMock: vi.fn(),
+    permState: { can: true },
+  }),
+);
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAddMock }),
+}));
+
+vi.mock('@/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    can: () => permState.can,
+    permissionTooltip: () => '',
+  }),
+}));
+
+vi.mock('@/composables/axios', () => ({
+  decamelizeKeys: (data: unknown) => data,
+  useAuthenticatedInstance: () => ({
+    post: postMock,
+    put: putMock,
+    delete: deleteMock,
+  }),
+}));
+
+const stubs = {
+  Select: {
+    props: ['modelValue', 'options'],
+    emits: ['update:modelValue'],
+    template:
+      '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="o in options" :key="o.uuid" :value="o.uuid">{{ o.description }}</option></select>',
+  },
+  Label: { template: '<label><slot /></label>' },
+  Message: { template: '<div class="message"><slot /></div>' },
+  PrimaryButton: {
+    props: ['disabled'],
+    emits: ['click'],
+    template:
+      '<button :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  SecondaryButton: {
+    emits: ['click'],
+    template: '<button @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  ByComponentExportEntryFields: {
+    props: ['description', 'responsibleRoles'],
+    emits: ['update:description', 'update:responsibleRoles'],
+    template:
+      '<textarea :value="description" @input="$emit(\'update:description\', $event.target.value)" />',
+  },
+};
+
+function mountEditor(props: {
+  modelValue: ByComponentExport | undefined;
+  stmtId?: string;
+}) {
+  return mount(ByComponentExportEditor, {
+    props: {
+      sspId: 'ssp-1',
+      reqId: 'req-1',
+      byComponentId: 'bc-1',
+      ...props,
+    },
+    global: { stubs },
+  });
+}
+
+describe('ByComponentExportEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permState.can = true;
+    postMock.mockResolvedValue({ data: { data: {} } });
+    putMock.mockResolvedValue({ data: { data: {} } });
+    deleteMock.mockResolvedValue({});
+  });
+
+  it('renders empty states when there is no export data', () => {
+    const wrapper = mountEditor({ modelValue: undefined });
+    expect(wrapper.text()).toContain('No provided entries yet.');
+    expect(wrapper.text()).toContain('No responsibility entries yet.');
+  });
+
+  it('creates the export then the provided entry on first Add Provided', async () => {
+    postMock
+      .mockResolvedValueOnce({
+        data: { data: { description: '', remarks: '' } },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            uuid: 'p-1',
+            description: 'We provide X',
+            responsibleRoles: [],
+          },
+        },
+      });
+
+    const wrapper = mountEditor({ modelValue: undefined });
+    await wrapper.find('button').trigger('click'); // Add Provided
+    await wrapper.find('textarea').setValue('We provide X');
+    const saveButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Save')!;
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export',
+      expect.objectContaining({ description: '' }),
+      expect.anything(),
+    );
+    expect(postMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/provided',
+      expect.objectContaining({ description: 'We provide X' }),
+      expect.anything(),
+    );
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+  });
+
+  it('uses the statement-level route when stmtId is set', async () => {
+    postMock
+      .mockResolvedValueOnce({ data: { data: { description: '' } } })
+      .mockResolvedValueOnce({
+        data: { data: { uuid: 'p-1', description: 'x', responsibleRoles: [] } },
+      });
+
+    const wrapper = mountEditor({ modelValue: undefined, stmtId: 'stmt-1' });
+    await wrapper.find('button').trigger('click');
+    await wrapper.find('textarea').setValue('x');
+    const saveButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Save')!;
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    expect(postMock.mock.calls[0][0]).toBe(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/statements/stmt-1/by-components/bc-1/export',
+    );
+  });
+
+  it('edits an existing provided entry via PUT', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Original', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    putMock.mockResolvedValueOnce({
+      data: {
+        data: { uuid: 'p-1', description: 'Updated', responsibleRoles: [] },
+      },
+    });
+
+    const wrapper = mountEditor({ modelValue });
+    const editButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Edit')!;
+    await editButton.trigger('click');
+    await wrapper.find('textarea').setValue('Updated');
+    const saveButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Save')!;
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    expect(putMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/provided/p-1',
+      expect.objectContaining({ description: 'Updated' }),
+      expect.anything(),
+    );
+  });
+
+  it('removes a provided entry via DELETE', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Original', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    const wrapper = mountEditor({ modelValue });
+    const removeButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Remove')!;
+    await removeButton.trigger('click');
+    await flushPromises();
+
+    expect(deleteMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/provided/p-1',
+    );
+  });
+
+  it('blocks saving a new responsibility without a selected provided entry', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Provided A', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    const wrapper = mountEditor({ modelValue });
+    const addResponsibilityButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Add Responsibility')!;
+    await addResponsibilityButton.trigger('click');
+    const saveButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Save')!;
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain(
+      'Select a provided entry before saving this responsibility.',
+    );
+  });
+
+  it('creates a responsibility with the selected providedUuid', async () => {
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Provided A', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    postMock.mockResolvedValueOnce({
+      data: {
+        data: {
+          uuid: 'r-1',
+          description: 'My responsibility',
+          providedUuid: 'p-1',
+          responsibleRoles: [],
+        },
+      },
+    });
+
+    const wrapper = mountEditor({ modelValue });
+    const addResponsibilityButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Add Responsibility')!;
+    await addResponsibilityButton.trigger('click');
+    await wrapper.find('select').setValue('p-1');
+    await wrapper.find('textarea').setValue('My responsibility');
+    const saveButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Save')!;
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/control-implementation/implemented-requirements/req-1/by-components/bc-1/export/responsibilities',
+      expect.objectContaining({ providedUuid: 'p-1' }),
+      expect.anything(),
+    );
+  });
+
+  it('hides Add/Edit/Remove controls without ssp:update', () => {
+    permState.can = false;
+    const modelValue: ByComponentExport = {
+      uuid: 'exp-1',
+      description: '',
+      provided: [
+        { uuid: 'p-1', description: 'Provided A', responsibleRoles: [] },
+      ],
+      responsibilities: [],
+    };
+    const wrapper = mountEditor({ modelValue });
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text());
+    expect(buttonTexts).not.toContain('Add Provided');
+    expect(buttonTexts).not.toContain('Add Responsibility');
+    expect(buttonTexts).not.toContain('Edit');
+    expect(buttonTexts).not.toContain('Remove');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a CRUD UI for Export → Provided/Responsibility entries on the by-component editor, for both control-level and statement-level by-components, wired to BCH-1336's dedicated `/export`, `/export/provided`, and `/export/responsibilities` endpoints instead of the old whole-object PUT.
- Responsibility entries require selecting a Provided entry (`providedUuid`) before they can be saved; both entry types support responsible roles.
- Add/Edit/Remove controls are gated behind `ssp:update` via the existing `PermissionGate`/`usePermissions` infrastructure.
- `ByComponentEditForm`'s whole-object PUT now omits `export` so it can never race with the new per-entity endpoints; the `saved` event patches `export` back in from local state.

## Test plan
- [x] `vue-tsc --noEmit` clean
- [x] `eslint` clean
- [x] New component tests (`ByComponentExportEditor.spec.ts`) cover: create/edit/remove Provided, create/edit Responsibility with `providedUuid`, validation blocking a save without a selected Provided, control-level vs statement-level routing, empty states, and permission gating
- [x] Full `npm run test:unit` suite green (aside from one pre-existing, unrelated `LoginView.spec.ts` failure caused by a `localStorage` env issue present before this change)
- [x] Manually verified in a local demo environment (SSP → Control Implementation tab → edit a by-component → Export section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated editor for managing By-Component export entries.
  * Users can add, edit, and remove Provided entries and Responsibilities.
  * Added support for descriptions and responsible roles, including multiple associated parties.
  * Added validation requiring Responsibilities to be linked to a Provided entry.
  * Added permission-based controls and success/error notifications.

* **Bug Fixes**
  * Export data is now preserved correctly when saving By-Component details.

* **Tests**
  * Added coverage for export editing, validation, permissions, routing, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->