### PR TITLE
BCH-1344: Export Offerings tab for curating/publishing SSP export offerings

### DIFF
--- a/src/components/system-security-plans/ExportOfferingCreateForm.vue
+++ b/src/components/system-security-plans/ExportOfferingCreateForm.vue
@@ -1,0 +1,83 @@
+<template>
+  <form @submit.prevent="createOffering" class="space-y-4">
+    <div>
+      <Label for="offering-title" required>Title</Label>
+      <InputText id="offering-title" v-model="title" class="w-full" />
+    </div>
+    <div>
+      <Label for="offering-description">Description</Label>
+      <Textarea
+        id="offering-description"
+        v-model="description"
+        rows="3"
+        class="w-full"
+      />
+    </div>
+    <div
+      class="flex justify-end gap-3 pt-2 border-t border-gray-200 dark:border-slate-700"
+    >
+      <SecondaryButton type="button" @click="$emit('cancel')">
+        Cancel
+      </SecondaryButton>
+      <PrimaryButton type="submit" :disabled="!title.trim() || saving">
+        {{ saving ? 'Creating...' : 'Create Offering' }}
+      </PrimaryButton>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import InputText from '@/volt/InputText.vue';
+import Textarea from '@/volt/Textarea.vue';
+import Label from '@/volt/Label.vue';
+import PrimaryButton from '@/volt/PrimaryButton.vue';
+import SecondaryButton from '@/volt/SecondaryButton.vue';
+import { useAuthenticatedInstance } from '@/composables/axios';
+import type { DataResponse, ErrorBody, ErrorResponse } from '@/stores/types';
+import type { SSPExportOffering } from '@/types/ssp-export-offerings';
+import type { AxiosError } from 'axios';
+
+const props = defineProps<{ sspId: string }>();
+const emit = defineEmits<{
+  cancel: [];
+  created: [offering: SSPExportOffering];
+}>();
+
+const toast = useToast();
+const axiosInstance = useAuthenticatedInstance();
+
+const title = ref('');
+const description = ref('');
+const saving = ref(false);
+
+async function createOffering() {
+  if (!title.value.trim()) return;
+  saving.value = true;
+  try {
+    const response = await axiosInstance.post<DataResponse<SSPExportOffering>>(
+      `/api/oscal/system-security-plans/${props.sspId}/export-offerings`,
+      { title: title.value, description: description.value },
+    );
+    toast.add({
+      severity: 'success',
+      summary: 'Export offering created.',
+      life: 3000,
+    });
+    emit('created', response.data.data);
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body ||
+        'Failed to create export offering.',
+      life: 5000,
+    });
+  } finally {
+    saving.value = false;
+  }
+}
+</script>

--- a/src/components/system-security-plans/ExportOfferingCreateForm.vue
+++ b/src/components/system-security-plans/ExportOfferingCreateForm.vue
@@ -54,6 +54,7 @@ const saving = ref(false);
 
 async function createOffering() {
   if (!title.value.trim()) return;
+  if (saving.value) return;
   saving.value = true;
   try {
     const response = await axiosInstance.post<DataResponse<SSPExportOffering>>(

--- a/src/components/system-security-plans/ExportOfferingEditForm.vue
+++ b/src/components/system-security-plans/ExportOfferingEditForm.vue
@@ -1,0 +1,86 @@
+<template>
+  <form @submit.prevent="saveOffering" class="space-y-4">
+    <div>
+      <Label for="offering-edit-title" required>Title</Label>
+      <InputText id="offering-edit-title" v-model="title" class="w-full" />
+    </div>
+    <div>
+      <Label for="offering-edit-description">Description</Label>
+      <Textarea
+        id="offering-edit-description"
+        v-model="description"
+        rows="3"
+        class="w-full"
+      />
+    </div>
+    <div
+      class="flex justify-end gap-3 pt-2 border-t border-gray-200 dark:border-slate-700"
+    >
+      <SecondaryButton type="button" @click="$emit('cancel')">
+        Cancel
+      </SecondaryButton>
+      <PrimaryButton type="submit" :disabled="!title.trim() || saving">
+        {{ saving ? 'Saving...' : 'Save' }}
+      </PrimaryButton>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import InputText from '@/volt/InputText.vue';
+import Textarea from '@/volt/Textarea.vue';
+import Label from '@/volt/Label.vue';
+import PrimaryButton from '@/volt/PrimaryButton.vue';
+import SecondaryButton from '@/volt/SecondaryButton.vue';
+import { useAuthenticatedInstance } from '@/composables/axios';
+import type { DataResponse, ErrorBody, ErrorResponse } from '@/stores/types';
+import type { SSPExportOffering } from '@/types/ssp-export-offerings';
+import type { AxiosError } from 'axios';
+
+const props = defineProps<{
+  sspId: string;
+  offering: SSPExportOffering;
+}>();
+const emit = defineEmits<{
+  cancel: [];
+  saved: [offering: SSPExportOffering];
+}>();
+
+const toast = useToast();
+const axiosInstance = useAuthenticatedInstance();
+
+const title = ref(props.offering.title);
+const description = ref(props.offering.description);
+const saving = ref(false);
+
+async function saveOffering() {
+  if (!title.value.trim()) return;
+  saving.value = true;
+  try {
+    const response = await axiosInstance.put<DataResponse<SSPExportOffering>>(
+      `/api/oscal/system-security-plans/${props.sspId}/export-offerings/${props.offering.id}`,
+      { title: title.value, description: description.value },
+    );
+    toast.add({
+      severity: 'success',
+      summary: 'Export offering updated.',
+      life: 3000,
+    });
+    emit('saved', response.data.data);
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body ||
+        'Failed to update export offering.',
+      life: 5000,
+    });
+  } finally {
+    saving.value = false;
+  }
+}
+</script>

--- a/src/components/system-security-plans/ExportOfferingEditForm.vue
+++ b/src/components/system-security-plans/ExportOfferingEditForm.vue
@@ -57,11 +57,12 @@ const saving = ref(false);
 
 async function saveOffering() {
   if (!title.value.trim()) return;
+  if (saving.value) return;
   saving.value = true;
   try {
     const response = await axiosInstance.put<DataResponse<SSPExportOffering>>(
       `/api/oscal/system-security-plans/${props.sspId}/export-offerings/${props.offering.id}`,
-      { title: title.value, description: description.value },
+      { title: title.value.trim(), description: description.value },
     );
     toast.add({
       severity: 'success',

--- a/src/components/system-security-plans/ExportOfferingItemsDialog.vue
+++ b/src/components/system-security-plans/ExportOfferingItemsDialog.vue
@@ -1,0 +1,236 @@
+<template>
+  <div class="space-y-4">
+    <div
+      v-if="offering.status === 'revoked'"
+      class="text-sm text-gray-500 dark:text-slate-400"
+    >
+      This offering has been revoked and can no longer be modified.
+    </div>
+
+    <div v-if="!items.length" class="text-sm text-gray-500 dark:text-slate-400">
+      No items yet. Add one from the SSP's authored capabilities.
+    </div>
+
+    <div v-else class="space-y-2">
+      <div
+        v-for="item in items"
+        :key="item.id"
+        class="p-3 border border-ccf-200 dark:border-slate-600 rounded flex justify-between items-start"
+      >
+        <div class="text-sm dark:text-slate-300">
+          <div class="font-medium">
+            {{ item.controlId }}
+            <span v-if="item.statementId">
+              · Statement {{ item.statementId }}</span
+            >
+          </div>
+          <div class="text-gray-500 dark:text-slate-400">
+            {{
+              componentTitleByUuid.get(item.componentUuid) ?? item.componentUuid
+            }}
+            —
+            {{
+              providedDescriptionByUuid.get(item.providedUuid) ??
+              item.providedUuid
+            }}
+          </div>
+        </div>
+        <PermissionGate
+          :resource="RESOURCES.SSP_EXPORT_OFFERING"
+          :action="ACTIONS.DELETE"
+        >
+          <button
+            v-if="offering.status !== 'revoked'"
+            type="button"
+            class="text-red-500 hover:text-red-700 text-sm shrink-0 ml-2"
+            @click="removeItem(item)"
+          >
+            Remove
+          </button>
+        </PermissionGate>
+      </div>
+    </div>
+
+    <PermissionGate
+      :resource="RESOURCES.SSP_EXPORT_OFFERING"
+      :action="ACTIONS.CREATE"
+    >
+      <div
+        v-if="offering.status !== 'revoked'"
+        class="pt-3 border-t border-gray-200 dark:border-slate-700"
+      >
+        <Label for="capability-picker">Add item</Label>
+        <Select
+          id="capability-picker"
+          v-model="selectedCapabilityKey"
+          :options="availableCapabilities"
+          option-label="label"
+          option-value="key"
+          placeholder="Select a capability to offer"
+          class="w-full"
+        />
+        <div class="flex justify-end mt-2">
+          <PrimaryButton
+            type="button"
+            :disabled="!selectedCapabilityKey || adding"
+            @click="addItem"
+          >
+            Add Item
+          </PrimaryButton>
+        </div>
+      </div>
+    </PermissionGate>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import Select from '@/volt/Select.vue';
+import Label from '@/volt/Label.vue';
+import PrimaryButton from '@/volt/PrimaryButton.vue';
+import PermissionGate from '@/components/auth/PermissionGate.vue';
+import { RESOURCES, ACTIONS } from '@/constants/permissions';
+import { useAuthenticatedInstance } from '@/composables/axios';
+import {
+  useOfferableCapabilities,
+  type OfferableCapability,
+} from '@/composables/useOfferableCapabilities';
+import type { ControlImplementation, SystemImplementation } from '@/oscal';
+import type { DataResponse, ErrorBody, ErrorResponse } from '@/stores/types';
+import type {
+  SSPExportOffering,
+  SSPExportOfferingItem,
+} from '@/types/ssp-export-offerings';
+import type { AxiosError } from 'axios';
+
+const props = defineProps<{
+  sspId: string;
+  offering: SSPExportOffering;
+  controlImplementation: ControlImplementation | undefined;
+  systemImplementation: SystemImplementation | undefined;
+}>();
+
+const emit = defineEmits<{
+  updated: [items: SSPExportOfferingItem[]];
+}>();
+
+const toast = useToast();
+const axiosInstance = useAuthenticatedInstance();
+
+const items = ref<SSPExportOfferingItem[]>([...(props.offering.items ?? [])]);
+
+const controlImplementationRef = computed(() => props.controlImplementation);
+const systemImplementationRef = computed(() => props.systemImplementation);
+const { capabilities } = useOfferableCapabilities(
+  controlImplementationRef,
+  systemImplementationRef,
+);
+
+function capabilityKey(c: {
+  controlId: string;
+  statementId?: string;
+  componentUuid: string;
+  providedUuid: string;
+}): string {
+  return [
+    c.controlId,
+    c.statementId ?? '',
+    c.componentUuid,
+    c.providedUuid,
+  ].join('::');
+}
+
+const componentTitleByUuid = computed(() => {
+  const map = new Map<string, string>();
+  for (const c of capabilities.value) {
+    map.set(c.componentUuid, c.componentTitle);
+  }
+  return map;
+});
+
+const providedDescriptionByUuid = computed(() => {
+  const map = new Map<string, string>();
+  for (const c of capabilities.value) {
+    map.set(c.providedUuid, c.providedDescription);
+  }
+  return map;
+});
+
+const existingItemKeys = computed(
+  () => new Set(items.value.map((item) => capabilityKey(item))),
+);
+
+const availableCapabilities = computed(() =>
+  capabilities.value
+    .filter((c) => !existingItemKeys.value.has(capabilityKey(c)))
+    .map((c) => ({
+      key: capabilityKey(c),
+      label: `${c.controlId}${c.statementId ? ` · Statement ${c.statementId}` : ''} · ${c.componentTitle} · ${c.providedDescription}`,
+      capability: c,
+    })),
+);
+
+const selectedCapabilityKey = ref<string | null>(null);
+const adding = ref(false);
+
+function findCapability(key: string): OfferableCapability | undefined {
+  return availableCapabilities.value.find((c) => c.key === key)?.capability;
+}
+
+async function addItem() {
+  if (!selectedCapabilityKey.value) return;
+  const capability = findCapability(selectedCapabilityKey.value);
+  if (!capability) return;
+
+  adding.value = true;
+  try {
+    const response = await axiosInstance.post<
+      DataResponse<SSPExportOfferingItem>
+    >(
+      `/api/oscal/system-security-plans/${props.sspId}/export-offerings/${props.offering.id}/items`,
+      {
+        controlId: capability.controlId,
+        statementId: capability.statementId,
+        componentUuid: capability.componentUuid,
+        providedUuid: capability.providedUuid,
+      },
+    );
+    items.value = [...items.value, response.data.data];
+    selectedCapabilityKey.value = null;
+    emit('updated', items.value);
+    toast.add({ severity: 'success', summary: 'Item added.', life: 3000 });
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body || 'Failed to add item.',
+      life: 5000,
+    });
+  } finally {
+    adding.value = false;
+  }
+}
+
+async function removeItem(item: SSPExportOfferingItem) {
+  try {
+    await axiosInstance.delete(
+      `/api/oscal/system-security-plans/${props.sspId}/export-offerings/${props.offering.id}/items/${item.id}`,
+    );
+    items.value = items.value.filter((i) => i.id !== item.id);
+    emit('updated', items.value);
+    toast.add({ severity: 'success', summary: 'Item removed.', life: 3000 });
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body || 'Failed to remove item.',
+      life: 5000,
+    });
+  }
+}
+</script>

--- a/src/components/system-security-plans/__tests__/ExportOfferingItemsDialog.spec.ts
+++ b/src/components/system-security-plans/__tests__/ExportOfferingItemsDialog.spec.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import ExportOfferingItemsDialog from '../ExportOfferingItemsDialog.vue';
+import type { ControlImplementation, SystemImplementation } from '@/oscal';
+import type { SSPExportOffering } from '@/types/ssp-export-offerings';
+
+const { postMock, deleteMock, toastAddMock, permState } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  deleteMock: vi.fn(),
+  toastAddMock: vi.fn(),
+  permState: { can: true },
+}));
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAddMock }),
+}));
+
+vi.mock('@/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    can: () => permState.can,
+    permissionTooltip: () => '',
+  }),
+}));
+
+vi.mock('@/composables/axios', () => ({
+  useAuthenticatedInstance: () => ({
+    post: postMock,
+    delete: deleteMock,
+  }),
+}));
+
+const stubs = {
+  Select: {
+    props: ['modelValue', 'options'],
+    emits: ['update:modelValue'],
+    template:
+      '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="o in options" :key="o.key" :value="o.key">{{ o.label }}</option></select>',
+  },
+  Label: { template: '<label><slot /></label>' },
+  PrimaryButton: {
+    props: ['disabled'],
+    emits: ['click'],
+    template:
+      '<button :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+};
+
+const systemImplementation: SystemImplementation = {
+  users: [],
+  components: [
+    {
+      uuid: 'comp-1',
+      type: 'software',
+      title: 'API',
+      description: '',
+      status: { state: 'operational' },
+    },
+  ],
+};
+
+const controlImplementation: ControlImplementation = {
+  description: '',
+  implementedRequirements: [
+    {
+      uuid: 'req-1',
+      controlId: 'ac-1',
+      byComponents: [
+        {
+          uuid: 'bc-1',
+          componentUuid: 'comp-1',
+          description: '',
+          export: {
+            uuid: 'exp-1',
+            description: '',
+            provided: [
+              { uuid: 'p-1', description: 'We provide access control' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+function makeOffering(
+  overrides: Partial<SSPExportOffering> = {},
+): SSPExportOffering {
+  return {
+    id: 'offering-1',
+    sspId: 'ssp-1',
+    title: 'My Offering',
+    description: '',
+    version: 0,
+    status: 'draft',
+    contentHash: '',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    items: [],
+    ...overrides,
+  };
+}
+
+function findButton(wrapper: ReturnType<typeof mount>, text: string) {
+  const button = wrapper.findAll('button').find((b) => b.text() === text);
+  if (!button) throw new Error(`Button with text "${text}" not found`);
+  return button;
+}
+
+describe('ExportOfferingItemsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permState.can = true;
+    postMock.mockResolvedValue({ data: { data: {} } });
+    deleteMock.mockResolvedValue({});
+  });
+
+  it('renders an empty state when the offering has no items', () => {
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering(),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+    expect(wrapper.text()).toContain(
+      "No items yet. Add one from the SSP's authored capabilities.",
+    );
+  });
+
+  it('adds an item for the selected capability', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 'item-1',
+          offeringId: 'offering-1',
+          controlId: 'ac-1',
+          componentUuid: 'comp-1',
+          providedUuid: 'p-1',
+        },
+      },
+    });
+
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering(),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+
+    await wrapper.find('select').setValue('ac-1::::comp-1::p-1');
+    await findButton(wrapper, 'Add Item').trigger('click');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings/offering-1/items',
+      {
+        controlId: 'ac-1',
+        statementId: undefined,
+        componentUuid: 'comp-1',
+        providedUuid: 'p-1',
+      },
+    );
+    expect(wrapper.emitted('updated')).toBeTruthy();
+    expect(wrapper.text()).toContain('ac-1');
+  });
+
+  it('removes an existing item', async () => {
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering({
+          items: [
+            {
+              id: 'item-1',
+              offeringId: 'offering-1',
+              controlId: 'ac-1',
+              componentUuid: 'comp-1',
+              providedUuid: 'p-1',
+            },
+          ],
+        }),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+
+    await findButton(wrapper, 'Remove').trigger('click');
+    await flushPromises();
+
+    expect(deleteMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings/offering-1/items/item-1',
+    );
+    const emitted = wrapper.emitted('updated');
+    expect(emitted).toBeTruthy();
+    expect(emitted![emitted!.length - 1][0]).toEqual([]);
+  });
+
+  it('hides Add/Remove controls without the corresponding permission', () => {
+    permState.can = false;
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering({
+          items: [
+            {
+              id: 'item-1',
+              offeringId: 'offering-1',
+              controlId: 'ac-1',
+              componentUuid: 'comp-1',
+              providedUuid: 'p-1',
+            },
+          ],
+        }),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text());
+    expect(buttonTexts).not.toContain('Add Item');
+    expect(buttonTexts).not.toContain('Remove');
+  });
+
+  it('disables Add/Remove controls once the offering is revoked', () => {
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering({
+          status: 'revoked',
+          items: [
+            {
+              id: 'item-1',
+              offeringId: 'offering-1',
+              controlId: 'ac-1',
+              componentUuid: 'comp-1',
+              providedUuid: 'p-1',
+            },
+          ],
+        }),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+
+    expect(wrapper.text()).toContain(
+      'This offering has been revoked and can no longer be modified.',
+    );
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text());
+    expect(buttonTexts).not.toContain('Add Item');
+    expect(buttonTexts).not.toContain('Remove');
+  });
+});

--- a/src/components/system-security-plans/__tests__/ExportOfferingItemsDialog.spec.ts
+++ b/src/components/system-security-plans/__tests__/ExportOfferingItemsDialog.spec.ts
@@ -201,6 +201,65 @@ describe('ExportOfferingItemsDialog', () => {
     expect(emitted![emitted!.length - 1][0]).toEqual([]);
   });
 
+  it('shows an error toast when adding an item fails', async () => {
+    postMock.mockRejectedValueOnce(new Error('network down'));
+
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering(),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+
+    await wrapper.find('select').setValue('ac-1::::comp-1::p-1');
+    await findButton(wrapper, 'Add Item').trigger('click');
+    await flushPromises();
+
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        detail: 'Failed to add item.',
+      }),
+    );
+  });
+
+  it('shows an error toast when removing an item fails', async () => {
+    deleteMock.mockRejectedValueOnce(new Error('network down'));
+
+    const wrapper = mount(ExportOfferingItemsDialog, {
+      props: {
+        sspId: 'ssp-1',
+        offering: makeOffering({
+          items: [
+            {
+              id: 'item-1',
+              offeringId: 'offering-1',
+              controlId: 'ac-1',
+              componentUuid: 'comp-1',
+              providedUuid: 'p-1',
+            },
+          ],
+        }),
+        controlImplementation,
+        systemImplementation,
+      },
+      global: { stubs },
+    });
+
+    await findButton(wrapper, 'Remove').trigger('click');
+    await flushPromises();
+
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        detail: 'Failed to remove item.',
+      }),
+    );
+  });
+
   it('hides Add/Remove controls without the corresponding permission', () => {
     permState.can = false;
     const wrapper = mount(ExportOfferingItemsDialog, {

--- a/src/composables/__tests__/useOfferableCapabilities.spec.ts
+++ b/src/composables/__tests__/useOfferableCapabilities.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { useOfferableCapabilities } from '../useOfferableCapabilities';
+import type { ControlImplementation, SystemImplementation } from '@/oscal';
+
+function makeSystemImplementation(): SystemImplementation {
+  return {
+    users: [],
+    components: [
+      {
+        uuid: 'comp-1',
+        type: 'software',
+        title: 'API',
+        description: '',
+        status: { state: 'operational' },
+      },
+    ],
+  };
+}
+
+describe('useOfferableCapabilities', () => {
+  it('returns an empty list when there is no control implementation', () => {
+    const { capabilities } = useOfferableCapabilities(
+      ref(undefined),
+      ref(undefined),
+    );
+    expect(capabilities.value).toEqual([]);
+  });
+
+  it('flattens a control-level by-component provided entry', () => {
+    const controlImplementation: ControlImplementation = {
+      description: '',
+      implementedRequirements: [
+        {
+          uuid: 'req-1',
+          controlId: 'ac-1',
+          byComponents: [
+            {
+              uuid: 'bc-1',
+              componentUuid: 'comp-1',
+              description: '',
+              export: {
+                uuid: 'exp-1',
+                description: '',
+                provided: [
+                  {
+                    uuid: 'p-1',
+                    description: 'We provide access control',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const { capabilities } = useOfferableCapabilities(
+      ref(controlImplementation),
+      ref(makeSystemImplementation()),
+    );
+
+    expect(capabilities.value).toEqual([
+      {
+        controlId: 'ac-1',
+        statementId: undefined,
+        componentUuid: 'comp-1',
+        componentTitle: 'API',
+        providedUuid: 'p-1',
+        providedDescription: 'We provide access control',
+      },
+    ]);
+  });
+
+  it('flattens a statement-level by-component provided entry with statementId set', () => {
+    const controlImplementation: ControlImplementation = {
+      description: '',
+      implementedRequirements: [
+        {
+          uuid: 'req-1',
+          controlId: 'ac-1',
+          statements: [
+            {
+              uuid: 'stmt-1',
+              statementId: 'ac-1_smt.a',
+              byComponents: [
+                {
+                  uuid: 'bc-1',
+                  componentUuid: 'comp-1',
+                  description: '',
+                  export: {
+                    uuid: 'exp-1',
+                    description: '',
+                    provided: [
+                      {
+                        uuid: 'p-1',
+                        description: 'Statement-level capability',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { capabilities } = useOfferableCapabilities(
+      ref(controlImplementation),
+      ref(makeSystemImplementation()),
+    );
+
+    expect(capabilities.value).toEqual([
+      {
+        controlId: 'ac-1',
+        statementId: 'ac-1_smt.a',
+        componentUuid: 'comp-1',
+        componentTitle: 'API',
+        providedUuid: 'p-1',
+        providedDescription: 'Statement-level capability',
+      },
+    ]);
+  });
+
+  it('falls back to the component uuid when no matching component title is found', () => {
+    const controlImplementation: ControlImplementation = {
+      description: '',
+      implementedRequirements: [
+        {
+          uuid: 'req-1',
+          controlId: 'ac-1',
+          byComponents: [
+            {
+              uuid: 'bc-1',
+              componentUuid: 'unknown-comp',
+              description: '',
+              export: {
+                uuid: 'exp-1',
+                description: '',
+                provided: [{ uuid: 'p-1', description: '' }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const { capabilities } = useOfferableCapabilities(
+      ref(controlImplementation),
+      ref(makeSystemImplementation()),
+    );
+
+    expect(capabilities.value[0].componentTitle).toBe('unknown-comp');
+    expect(capabilities.value[0].providedDescription).toBe('p-1');
+  });
+});

--- a/src/composables/useOfferableCapabilities.ts
+++ b/src/composables/useOfferableCapabilities.ts
@@ -1,5 +1,9 @@
 import { computed, type Ref } from 'vue';
-import type { ControlImplementation, SystemImplementation } from '@/oscal';
+import type {
+  ByComponent,
+  ControlImplementation,
+  SystemImplementation,
+} from '@/oscal';
 
 export interface OfferableCapability {
   controlId: string;
@@ -8,6 +12,32 @@ export interface OfferableCapability {
   componentTitle: string;
   providedUuid: string;
   providedDescription: string;
+}
+
+// Appends one OfferableCapability per provided entry across a set of by-components — shared
+// by the control-level and statement-level walks below, which differ only in whether a
+// statementId is set.
+function appendCapabilities(
+  byComponents: ByComponent[] | undefined,
+  controlId: string,
+  statementId: string | undefined,
+  componentTitleByUuid: Map<string, string>,
+  result: OfferableCapability[],
+) {
+  for (const byComponent of byComponents ?? []) {
+    for (const provided of byComponent.export?.provided ?? []) {
+      result.push({
+        controlId,
+        statementId,
+        componentUuid: byComponent.componentUuid,
+        componentTitle:
+          componentTitleByUuid.get(byComponent.componentUuid) ??
+          byComponent.componentUuid,
+        providedUuid: provided.uuid,
+        providedDescription: provided.description || provided.uuid,
+      });
+    }
+  }
 }
 
 // Flattens an SSP's authored control-implementation tree (BCH-1343) into the set of
@@ -33,35 +63,22 @@ export function useOfferableCapabilities(
       controlImplementation.value?.implementedRequirements ?? [];
 
     for (const requirement of requirements) {
-      for (const byComponent of requirement.byComponents ?? []) {
-        for (const provided of byComponent.export?.provided ?? []) {
-          result.push({
-            controlId: requirement.controlId,
-            componentUuid: byComponent.componentUuid,
-            componentTitle:
-              componentTitleByUuid.value.get(byComponent.componentUuid) ??
-              byComponent.componentUuid,
-            providedUuid: provided.uuid,
-            providedDescription: provided.description || provided.uuid,
-          });
-        }
-      }
+      appendCapabilities(
+        requirement.byComponents,
+        requirement.controlId,
+        undefined,
+        componentTitleByUuid.value,
+        result,
+      );
 
       for (const statement of requirement.statements ?? []) {
-        for (const byComponent of statement.byComponents ?? []) {
-          for (const provided of byComponent.export?.provided ?? []) {
-            result.push({
-              controlId: requirement.controlId,
-              statementId: statement.statementId,
-              componentUuid: byComponent.componentUuid,
-              componentTitle:
-                componentTitleByUuid.value.get(byComponent.componentUuid) ??
-                byComponent.componentUuid,
-              providedUuid: provided.uuid,
-              providedDescription: provided.description || provided.uuid,
-            });
-          }
-        }
+        appendCapabilities(
+          statement.byComponents,
+          requirement.controlId,
+          statement.statementId,
+          componentTitleByUuid.value,
+          result,
+        );
       }
     }
 

--- a/src/composables/useOfferableCapabilities.ts
+++ b/src/composables/useOfferableCapabilities.ts
@@ -1,0 +1,72 @@
+import { computed, type Ref } from 'vue';
+import type { ControlImplementation, SystemImplementation } from '@/oscal';
+
+export interface OfferableCapability {
+  controlId: string;
+  statementId?: string;
+  componentUuid: string;
+  componentTitle: string;
+  providedUuid: string;
+  providedDescription: string;
+}
+
+// Flattens an SSP's authored control-implementation tree (BCH-1343) into the set of
+// (control, optional statement, component, provided) tuples an export offering can pick
+// from. There's no dedicated "what can I offer" endpoint — this is exactly the
+// Export/Provided data the by-component editor authors, read back and joined against
+// component titles.
+export function useOfferableCapabilities(
+  controlImplementation: Ref<ControlImplementation | undefined>,
+  systemImplementation: Ref<SystemImplementation | undefined>,
+) {
+  const componentTitleByUuid = computed(() => {
+    const map = new Map<string, string>();
+    for (const component of systemImplementation.value?.components ?? []) {
+      map.set(component.uuid, component.title);
+    }
+    return map;
+  });
+
+  const capabilities = computed<OfferableCapability[]>(() => {
+    const result: OfferableCapability[] = [];
+    const requirements =
+      controlImplementation.value?.implementedRequirements ?? [];
+
+    for (const requirement of requirements) {
+      for (const byComponent of requirement.byComponents ?? []) {
+        for (const provided of byComponent.export?.provided ?? []) {
+          result.push({
+            controlId: requirement.controlId,
+            componentUuid: byComponent.componentUuid,
+            componentTitle:
+              componentTitleByUuid.value.get(byComponent.componentUuid) ??
+              byComponent.componentUuid,
+            providedUuid: provided.uuid,
+            providedDescription: provided.description || provided.uuid,
+          });
+        }
+      }
+
+      for (const statement of requirement.statements ?? []) {
+        for (const byComponent of statement.byComponents ?? []) {
+          for (const provided of byComponent.export?.provided ?? []) {
+            result.push({
+              controlId: requirement.controlId,
+              statementId: statement.statementId,
+              componentUuid: byComponent.componentUuid,
+              componentTitle:
+                componentTitleByUuid.value.get(byComponent.componentUuid) ??
+                byComponent.componentUuid,
+              providedUuid: provided.uuid,
+              providedDescription: provided.description || provided.uuid,
+            });
+          }
+        }
+      }
+    }
+
+    return result;
+  });
+
+  return { capabilities };
+}

--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -24,6 +24,7 @@ export const RESOURCES = {
   PARTY: 'party',
   ROLE: 'role',
   ACTIVITY: 'activity',
+  SSP_EXPORT_OFFERING: 'ssp-export-offering',
 
   // SSP-scoped register items
   RISK: 'risk',
@@ -62,6 +63,7 @@ export const ACTIONS = {
   UPDATE: 'update',
   DELETE: 'delete',
   PROMOTE: 'promote',
+  EXPORT: 'export',
   INGEST: 'ingest',
   REGISTER: 'register',
   // admin actions
@@ -120,6 +122,7 @@ const RESOURCE_LABELS: Partial<Record<string, string>> = {
   [RESOURCES.PARTY]: 'parties',
   [RESOURCES.ROLE]: 'roles',
   [RESOURCES.ACTIVITY]: 'activities',
+  [RESOURCES.SSP_EXPORT_OFFERING]: 'export offerings',
   [RESOURCES.RISK]: 'risks',
   [RESOURCES.FILTER]: 'dashboards',
   [RESOURCES.DASHBOARD_SUGGESTION]: 'dashboard suggestions',
@@ -146,6 +149,7 @@ const ACTION_VERBS: Partial<Record<string, string>> = {
   [ACTIONS.UPDATE]: 'edit',
   [ACTIONS.DELETE]: 'delete',
   [ACTIONS.PROMOTE]: 'promote',
+  [ACTIONS.EXPORT]: 'publish',
   [ACTIONS.REGISTER]: 'register',
   [ACTIONS.INGEST]: 'ingest',
   [ACTIONS.EXECUTE]: 'import',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -754,6 +754,14 @@ const authenticatedRoutes = [
           ),
       },
       {
+        path: 'export-offerings',
+        name: 'system-security-plan-export-offerings',
+        component: () =>
+          import(
+            '../views/system-security-plans/SystemSecurityPlanExportOfferingsView.vue'
+          ),
+      },
+      {
         path: 'risks',
         name: 'system-security-plan-risks',
         component: () => import('../views/RisksView.vue'),

--- a/src/types/ssp-export-offerings.ts
+++ b/src/types/ssp-export-offerings.ts
@@ -1,0 +1,33 @@
+// Types for the SSP export offering endpoints (BCH-1337). These are
+// hand-written, camelCase JSON API resources — not OSCAL — so they live here
+// rather than in src/oscal, and requests must not use decamelizeKeys.
+
+export type SSPExportOfferingStatus =
+  | 'draft'
+  | 'published'
+  | 'deprecated'
+  | 'revoked';
+
+export interface SSPExportOfferingItem {
+  id: string;
+  offeringId: string;
+  controlId: string;
+  statementId?: string;
+  componentUuid: string;
+  providedUuid: string;
+}
+
+export interface SSPExportOffering {
+  id: string;
+  sspId: string;
+  title: string;
+  description: string;
+  version: number;
+  status: SSPExportOfferingStatus;
+  contentHash: string;
+  publishedAt?: string;
+  createdById?: string;
+  createdAt: string;
+  updatedAt: string;
+  items?: SSPExportOfferingItem[];
+}

--- a/src/views/system-security-plans/SystemSecurityPlanEditorView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanEditorView.vue
@@ -53,6 +53,15 @@
       </RouterLink>
       <RouterLink
         class="tab-link px-4 py-2 inline-block text-lg border-ccf-300 dark:border-slate-700 dark:hover:bg-slate-900"
+        :to="{
+          name: 'system-security-plan-export-offerings',
+          params: { id: sspId },
+        }"
+      >
+        Export Offerings
+      </RouterLink>
+      <RouterLink
+        class="tab-link px-4 py-2 inline-block text-lg border-ccf-300 dark:border-slate-700 dark:hover:bg-slate-900"
         :to="{ name: 'system-security-plan-risks', params: { id: sspId } }"
       >
         Risks

--- a/src/views/system-security-plans/SystemSecurityPlanExportOfferingsView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanExportOfferingsView.vue
@@ -1,0 +1,344 @@
+<template>
+  <div class="space-y-6">
+    <div
+      class="bg-white dark:bg-slate-900 border border-ccf-300 dark:border-slate-700 rounded-lg p-6"
+    >
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-slate-300">
+          Export Offerings
+        </h3>
+        <PermissionGate
+          :resource="RESOURCES.SSP_EXPORT_OFFERING"
+          :action="ACTIONS.CREATE"
+        >
+          <PrimaryButton @click="showCreateModal = true">
+            Create Offering
+          </PrimaryButton>
+        </PermissionGate>
+      </div>
+
+      <div v-if="loading" class="text-center py-4">
+        <p class="text-gray-500 dark:text-slate-400">
+          Loading export offerings...
+        </p>
+      </div>
+
+      <div v-else-if="!offerings?.length" class="text-center py-8">
+        <p class="text-gray-500 dark:text-slate-400">
+          No export offerings yet. Click "Create Offering" to get started.
+        </p>
+      </div>
+
+      <div v-else class="space-y-4">
+        <div
+          v-for="offering in offerings"
+          :key="offering.id"
+          class="border border-gray-200 dark:border-slate-700 rounded-lg p-4"
+        >
+          <div class="flex justify-between items-start mb-2">
+            <div>
+              <div class="flex items-center gap-2">
+                <h4 class="font-medium text-gray-900 dark:text-slate-300">
+                  {{ offering.title }}
+                </h4>
+                <Badge :severity="statusSeverity(offering.status)">
+                  {{ offering.status }}
+                </Badge>
+                <span class="text-xs text-gray-500 dark:text-slate-400">
+                  v{{ offering.version }}
+                </span>
+              </div>
+              <p
+                v-if="offering.description"
+                class="text-sm text-gray-600 dark:text-slate-400 mt-1"
+              >
+                {{ offering.description }}
+              </p>
+              <p class="text-xs text-gray-500 dark:text-slate-400 mt-1">
+                {{
+                  offering.publishedAt
+                    ? `Published ${formatDate(offering.publishedAt)}`
+                    : 'Not yet published'
+                }}
+              </p>
+            </div>
+            <div class="flex gap-3 shrink-0 ml-4">
+              <PermissionGate
+                :resource="RESOURCES.SSP_EXPORT_OFFERING"
+                :action="ACTIONS.UPDATE"
+              >
+                <button
+                  type="button"
+                  class="text-blue-600 hover:text-blue-800 dark:text-blue-400 text-sm"
+                  @click="openEditModal(offering)"
+                >
+                  Edit
+                </button>
+              </PermissionGate>
+              <button
+                type="button"
+                class="text-gray-600 hover:text-gray-800 dark:text-slate-400 text-sm"
+                @click="openItemsModal(offering)"
+              >
+                Manage Items ({{ offering.items?.length ?? 0 }})
+              </button>
+              <PermissionGate
+                :resource="RESOURCES.SSP"
+                :action="ACTIONS.EXPORT"
+              >
+                <button
+                  v-if="
+                    offering.status === 'draft' ||
+                    offering.status === 'published'
+                  "
+                  type="button"
+                  class="text-green-600 hover:text-green-800 dark:text-green-400 text-sm"
+                  @click="publish(offering)"
+                >
+                  {{ offering.status === 'draft' ? 'Publish' : 'Republish' }}
+                </button>
+                <button
+                  v-if="offering.status === 'published'"
+                  type="button"
+                  class="text-orange-600 hover:text-orange-800 dark:text-orange-400 text-sm"
+                  @click="confirmStatusChange(offering, 'deprecated')"
+                >
+                  Deprecate
+                </button>
+                <button
+                  v-if="offering.status === 'published'"
+                  type="button"
+                  class="text-red-600 hover:text-red-800 dark:text-red-400 text-sm"
+                  @click="confirmStatusChange(offering, 'revoked')"
+                >
+                  Revoke
+                </button>
+              </PermissionGate>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <Dialog
+      v-model:visible="showCreateModal"
+      size="lg"
+      modal
+      header="Create Export Offering"
+    >
+      <ExportOfferingCreateForm
+        :ssp-id="sspId"
+        @cancel="showCreateModal = false"
+        @created="handleCreated"
+      />
+    </Dialog>
+
+    <Dialog
+      v-model:visible="showEditModal"
+      size="lg"
+      modal
+      header="Edit Export Offering"
+    >
+      <ExportOfferingEditForm
+        v-if="editingOffering"
+        :ssp-id="sspId"
+        :offering="editingOffering"
+        @cancel="showEditModal = false"
+        @saved="handleSaved"
+      />
+    </Dialog>
+
+    <Dialog
+      v-model:visible="showItemsModal"
+      size="xl"
+      modal
+      :header="`Manage Items — ${itemsOffering?.title ?? ''}`"
+    >
+      <ExportOfferingItemsDialog
+        v-if="itemsOffering"
+        :ssp-id="sspId"
+        :offering="itemsOffering"
+        :control-implementation="controlImplementation"
+        :system-implementation="systemImplementation"
+        @updated="handleItemsUpdated"
+      />
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useToast } from 'primevue/usetoast';
+import { useConfirm } from 'primevue/useconfirm';
+import Dialog from '@/volt/Dialog.vue';
+import Badge from '@/volt/Badge.vue';
+import PrimaryButton from '@/volt/PrimaryButton.vue';
+import PermissionGate from '@/components/auth/PermissionGate.vue';
+import ExportOfferingCreateForm from '@/components/system-security-plans/ExportOfferingCreateForm.vue';
+import ExportOfferingEditForm from '@/components/system-security-plans/ExportOfferingEditForm.vue';
+import ExportOfferingItemsDialog from '@/components/system-security-plans/ExportOfferingItemsDialog.vue';
+import { RESOURCES, ACTIONS } from '@/constants/permissions';
+import { useDataApi, useAuthenticatedInstance } from '@/composables/axios';
+import { getIdFromRoute } from '@/utils/get-poam-id-from-route';
+import type { ControlImplementation, SystemImplementation } from '@/oscal';
+import type { DataResponse, ErrorBody, ErrorResponse } from '@/stores/types';
+import type {
+  SSPExportOffering,
+  SSPExportOfferingItem,
+  SSPExportOfferingStatus,
+} from '@/types/ssp-export-offerings';
+import type { AxiosError } from 'axios';
+
+const route = useRoute();
+const toast = useToast();
+const confirm = useConfirm();
+const axiosInstance = useAuthenticatedInstance();
+
+const sspId = computed(() => getIdFromRoute(route) ?? '');
+
+const { data: offerings, isLoading: loading } = useDataApi<SSPExportOffering[]>(
+  `/api/oscal/system-security-plans/${sspId.value}/export-offerings`,
+);
+
+const { data: controlImplementation } = useDataApi<ControlImplementation>(
+  `/api/oscal/system-security-plans/${sspId.value}/control-implementation`,
+);
+const { data: systemImplementation } = useDataApi<SystemImplementation>(
+  `/api/oscal/system-security-plans/${sspId.value}/system-implementation`,
+);
+
+const showCreateModal = ref(false);
+const showEditModal = ref(false);
+const showItemsModal = ref(false);
+const editingOffering = ref<SSPExportOffering | null>(null);
+const itemsOffering = ref<SSPExportOffering | null>(null);
+
+function statusSeverity(status: SSPExportOfferingStatus) {
+  switch (status) {
+    case 'published':
+      return 'success';
+    case 'deprecated':
+      return 'warn';
+    case 'revoked':
+      return 'danger';
+    default:
+      return 'secondary';
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-GB', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function replaceOffering(updated: SSPExportOffering) {
+  if (!offerings.value) return;
+  const index = offerings.value.findIndex((o) => o.id === updated.id);
+  if (index !== -1) {
+    offerings.value[index] = updated;
+  }
+}
+
+function handleCreated(offering: SSPExportOffering) {
+  if (offerings.value) {
+    offerings.value.push(offering);
+  }
+  showCreateModal.value = false;
+}
+
+function openEditModal(offering: SSPExportOffering) {
+  editingOffering.value = offering;
+  showEditModal.value = true;
+}
+
+function handleSaved(offering: SSPExportOffering) {
+  replaceOffering(offering);
+  showEditModal.value = false;
+  editingOffering.value = null;
+}
+
+function openItemsModal(offering: SSPExportOffering) {
+  itemsOffering.value = offering;
+  showItemsModal.value = true;
+}
+
+function handleItemsUpdated(items: SSPExportOfferingItem[]) {
+  if (itemsOffering.value) {
+    itemsOffering.value = { ...itemsOffering.value, items };
+    replaceOffering(itemsOffering.value);
+  }
+}
+
+async function publish(offering: SSPExportOffering) {
+  try {
+    const response = await axiosInstance.post<DataResponse<SSPExportOffering>>(
+      `/api/oscal/system-security-plans/${sspId.value}/export-offerings/${offering.id}/publish`,
+    );
+    replaceOffering(response.data.data);
+    toast.add({
+      severity: 'success',
+      summary: 'Export offering published.',
+      life: 3000,
+    });
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body ||
+        'Failed to publish export offering.',
+      life: 5000,
+    });
+  }
+}
+
+function confirmStatusChange(
+  offering: SSPExportOffering,
+  status: 'deprecated' | 'revoked',
+) {
+  const verb = status === 'deprecated' ? 'deprecate' : 'revoke';
+  confirm.require({
+    message: `Are you sure you want to ${verb} "${offering.title}"? This action cannot be undone.`,
+    header:
+      status === 'deprecated' ? 'Confirm Deprecation' : 'Confirm Revocation',
+    rejectProps: { label: 'Cancel', severity: 'secondary', outlined: true },
+    acceptProps: { label: 'Confirm' },
+    accept: async () => {
+      await updateStatus(offering, status);
+    },
+  });
+}
+
+async function updateStatus(
+  offering: SSPExportOffering,
+  status: 'deprecated' | 'revoked',
+) {
+  try {
+    const response = await axiosInstance.patch<DataResponse<SSPExportOffering>>(
+      `/api/oscal/system-security-plans/${sspId.value}/export-offerings/${offering.id}/status`,
+      { status },
+    );
+    replaceOffering(response.data.data);
+    toast.add({
+      severity: 'success',
+      summary: `Export offering ${status}.`,
+      life: 3000,
+    });
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body ||
+        `Failed to ${status === 'deprecated' ? 'deprecate' : 'revoke'} export offering.`,
+      life: 5000,
+    });
+  }
+}
+</script>

--- a/src/views/system-security-plans/SystemSecurityPlanExportOfferingsView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanExportOfferingsView.vue
@@ -93,6 +93,7 @@
                   "
                   type="button"
                   class="text-green-600 hover:text-green-800 dark:text-green-400 text-sm"
+                  :disabled="publishingIds.has(offering.id)"
                   @click="publish(offering)"
                 >
                   {{ offering.status === 'draft' ? 'Publish' : 'Republish' }}
@@ -167,7 +168,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useToast } from 'primevue/usetoast';
 import { useConfirm } from 'primevue/useconfirm';
@@ -213,6 +214,7 @@ const showEditModal = ref(false);
 const showItemsModal = ref(false);
 const editingOffering = ref<SSPExportOffering | null>(null);
 const itemsOffering = ref<SSPExportOffering | null>(null);
+const publishingIds = reactive(new Set<string>());
 
 function statusSeverity(status: SSPExportOfferingStatus) {
   switch (status) {
@@ -274,6 +276,8 @@ function handleItemsUpdated(items: SSPExportOfferingItem[]) {
 }
 
 async function publish(offering: SSPExportOffering) {
+  if (publishingIds.has(offering.id)) return;
+  publishingIds.add(offering.id);
   try {
     const response = await axiosInstance.post<DataResponse<SSPExportOffering>>(
       `/api/oscal/system-security-plans/${sspId.value}/export-offerings/${offering.id}/publish`,
@@ -294,6 +298,8 @@ async function publish(offering: SSPExportOffering) {
         'Failed to publish export offering.',
       life: 5000,
     });
+  } finally {
+    publishingIds.delete(offering.id);
   }
 }
 

--- a/src/views/system-security-plans/__tests__/SystemSecurityPlanExportOfferingsView.spec.ts
+++ b/src/views/system-security-plans/__tests__/SystemSecurityPlanExportOfferingsView.spec.ts
@@ -189,9 +189,9 @@ describe('SystemSecurityPlanExportOfferingsView', () => {
     const wrapper = mountView();
     await findButton(wrapper, 'Edit').trigger('click');
     const inputs = wrapper.findAll('input');
-    await inputs[inputs.length - 1].setValue('Renamed Offering');
+    await inputs.at(-1)!.setValue('Renamed Offering');
     const forms = wrapper.findAll('form');
-    await forms[forms.length - 1].trigger('submit');
+    await forms.at(-1)!.trigger('submit');
     await flushPromises();
 
     expect(putMock).toHaveBeenCalledWith(

--- a/src/views/system-security-plans/__tests__/SystemSecurityPlanExportOfferingsView.spec.ts
+++ b/src/views/system-security-plans/__tests__/SystemSecurityPlanExportOfferingsView.spec.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import SystemSecurityPlanExportOfferingsView from '../SystemSecurityPlanExportOfferingsView.vue';
+import type { SSPExportOffering } from '@/types/ssp-export-offerings';
+
+const {
+  postMock,
+  putMock,
+  patchMock,
+  toastAddMock,
+  confirmRequireMock,
+  permState,
+  offeringsData,
+} = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  putMock: vi.fn(),
+  patchMock: vi.fn(),
+  toastAddMock: vi.fn(),
+  confirmRequireMock: vi.fn(),
+  permState: { can: true },
+  offeringsData: { current: [] as SSPExportOffering[] },
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: 'ssp-1' } }),
+}));
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAddMock }),
+}));
+
+vi.mock('primevue/useconfirm', () => ({
+  useConfirm: () => ({ require: confirmRequireMock }),
+}));
+
+vi.mock('@/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    can: () => permState.can,
+    permissionTooltip: () => '',
+  }),
+}));
+
+vi.mock('@/composables/axios', async () => {
+  const { ref } = await import('vue');
+  return {
+    useDataApi: (url: string) => {
+      if (url.endsWith('/export-offerings')) {
+        return { data: ref(offeringsData.current), isLoading: ref(false) };
+      }
+      return { data: ref(undefined), isLoading: ref(false) };
+    },
+    useAuthenticatedInstance: () => ({
+      post: postMock,
+      put: putMock,
+      patch: patchMock,
+    }),
+  };
+});
+
+const stubs = {
+  Dialog: {
+    props: ['visible'],
+    template: '<div v-if="visible"><slot /></div>',
+  },
+  Badge: {
+    props: ['severity'],
+    template: '<span :data-severity="severity"><slot /></span>',
+  },
+  PrimaryButton: {
+    props: ['disabled'],
+    emits: ['click'],
+    template:
+      '<button :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  SecondaryButton: {
+    emits: ['click'],
+    template: '<button @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  InputText: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template:
+      '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  Textarea: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template:
+      '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  Label: { template: '<label><slot /></label>' },
+  Select: {
+    props: ['modelValue', 'options'],
+    emits: ['update:modelValue'],
+    template: '<select />',
+  },
+};
+
+function makeOffering(
+  overrides: Partial<SSPExportOffering> = {},
+): SSPExportOffering {
+  return {
+    id: 'offering-1',
+    sspId: 'ssp-1',
+    title: 'My Offering',
+    description: 'A useful offering',
+    version: 0,
+    status: 'draft',
+    contentHash: '',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    items: [],
+    ...overrides,
+  };
+}
+
+function findButton(wrapper: ReturnType<typeof mount>, text: string) {
+  const button = wrapper.findAll('button').find((b) => b.text() === text);
+  if (!button) throw new Error(`Button with text "${text}" not found`);
+  return button;
+}
+
+function mountView() {
+  return mount(SystemSecurityPlanExportOfferingsView, { global: { stubs } });
+}
+
+describe('SystemSecurityPlanExportOfferingsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permState.can = true;
+    offeringsData.current = [];
+    postMock.mockResolvedValue({ data: { data: {} } });
+    putMock.mockResolvedValue({ data: { data: {} } });
+    patchMock.mockResolvedValue({ data: { data: {} } });
+  });
+
+  it('renders an empty state when there are no offerings', () => {
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain(
+      'No export offerings yet. Click "Create Offering" to get started.',
+    );
+  });
+
+  it('renders an offering with its status badge, version, and publishedAt', () => {
+    offeringsData.current = [
+      makeOffering({
+        status: 'published',
+        version: 3,
+        publishedAt: '2026-02-01T00:00:00Z',
+      }),
+    ];
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain('My Offering');
+    expect(wrapper.text()).toContain('published');
+    expect(wrapper.text()).toContain('v3');
+    expect(wrapper.text()).toContain('Published');
+  });
+
+  it('shows "Not yet published" for a draft offering', () => {
+    offeringsData.current = [makeOffering()];
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain('Not yet published');
+  });
+
+  it('creates an offering and adds it to the list', async () => {
+    postMock.mockResolvedValueOnce({
+      data: { data: makeOffering({ id: 'new-offering', title: 'New One' }) },
+    });
+
+    const wrapper = mountView();
+    await findButton(wrapper, 'Create Offering').trigger('click');
+    await wrapper.find('input').setValue('New One');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings',
+      { title: 'New One', description: '' },
+    );
+    expect(wrapper.text()).toContain('New One');
+  });
+
+  it('edits an offering and reflects the change in the list', async () => {
+    offeringsData.current = [makeOffering()];
+    putMock.mockResolvedValueOnce({
+      data: { data: makeOffering({ title: 'Renamed Offering' }) },
+    });
+
+    const wrapper = mountView();
+    await findButton(wrapper, 'Edit').trigger('click');
+    const inputs = wrapper.findAll('input');
+    await inputs[inputs.length - 1].setValue('Renamed Offering');
+    const forms = wrapper.findAll('form');
+    await forms[forms.length - 1].trigger('submit');
+    await flushPromises();
+
+    expect(putMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings/offering-1',
+      { title: 'Renamed Offering', description: 'A useful offering' },
+    );
+    expect(wrapper.text()).toContain('Renamed Offering');
+  });
+
+  it('publishes a draft offering and updates status/version/publishedAt in place', async () => {
+    offeringsData.current = [makeOffering()];
+    postMock.mockResolvedValueOnce({
+      data: {
+        data: makeOffering({
+          status: 'published',
+          version: 1,
+          publishedAt: '2026-03-01T00:00:00Z',
+        }),
+      },
+    });
+
+    const wrapper = mountView();
+    await findButton(wrapper, 'Publish').trigger('click');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings/offering-1/publish',
+    );
+    expect(wrapper.text()).toContain('published');
+    expect(wrapper.text()).toContain('v1');
+  });
+
+  it('shows Republish for an already-published offering', () => {
+    offeringsData.current = [makeOffering({ status: 'published' })];
+    const wrapper = mountView();
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text());
+    expect(buttonTexts).toContain('Republish');
+    expect(buttonTexts).not.toContain('Publish');
+  });
+
+  it('deprecates a published offering after confirmation', async () => {
+    offeringsData.current = [makeOffering({ status: 'published' })];
+    patchMock.mockResolvedValueOnce({
+      data: { data: makeOffering({ status: 'deprecated' }) },
+    });
+
+    const wrapper = mountView();
+    await findButton(wrapper, 'Deprecate').trigger('click');
+    expect(confirmRequireMock).toHaveBeenCalled();
+
+    const { accept } = confirmRequireMock.mock.calls[0][0];
+    await accept();
+    await flushPromises();
+
+    expect(patchMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings/offering-1/status',
+      { status: 'deprecated' },
+    );
+    expect(wrapper.text()).toContain('deprecated');
+  });
+
+  it('revokes a published offering after confirmation', async () => {
+    offeringsData.current = [makeOffering({ status: 'published' })];
+    patchMock.mockResolvedValueOnce({
+      data: { data: makeOffering({ status: 'revoked' }) },
+    });
+
+    const wrapper = mountView();
+    await findButton(wrapper, 'Revoke').trigger('click');
+    const { accept } = confirmRequireMock.mock.calls[0][0];
+    await accept();
+    await flushPromises();
+
+    expect(patchMock).toHaveBeenCalledWith(
+      '/api/oscal/system-security-plans/ssp-1/export-offerings/offering-1/status',
+      { status: 'revoked' },
+    );
+    expect(wrapper.text()).toContain('revoked');
+  });
+
+  it('hides Deprecate/Revoke for a draft offering and Publish for a revoked one', () => {
+    offeringsData.current = [makeOffering({ status: 'revoked' })];
+    const wrapper = mountView();
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text());
+    expect(buttonTexts).not.toContain('Publish');
+    expect(buttonTexts).not.toContain('Republish');
+    expect(buttonTexts).not.toContain('Deprecate');
+    expect(buttonTexts).not.toContain('Revoke');
+  });
+
+  it('hides Create/Edit/Publish/Deprecate/Revoke without the corresponding permission', () => {
+    permState.can = false;
+    offeringsData.current = [makeOffering({ status: 'published' })];
+    const wrapper = mountView();
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text());
+    expect(buttonTexts).not.toContain('Create Offering');
+    expect(buttonTexts).not.toContain('Edit');
+    expect(buttonTexts).not.toContain('Republish');
+    expect(buttonTexts).not.toContain('Deprecate');
+    expect(buttonTexts).not.toContain('Revoke');
+  });
+});


### PR DESCRIPTION
## Summary
- New "Export Offerings" tab on the SSP editor: list offerings with status (draft/published/deprecated/revoked), version, and published date.
- Create/edit an offering (title + description).
- Pick offering items (control, optional statement, component, provided) from the SSP's authored Export/Provided capabilities (BCH-1343) via a new `useOfferableCapabilities` composable that flattens the control-implementation tree.
- Publish / Deprecate / Revoke actions, wired to BCH-1337's endpoints, updating status/version/published_at in place.
- Publish gated on `ssp:export`; offering/item CRUD gated on `ssp-export-offering` permissions — both via the existing `PermissionGate`/`usePermissions` infrastructure (new `SSP_EXPORT_OFFERING` resource and `EXPORT` action added to `src/constants/permissions.ts`).
- Deliberately no Delete-offering UI action — not in the ticket's scope, even though the API supports it.

## Test plan
- [x] `vue-tsc --build` clean (project-wide, including test files)
- [x] `eslint` clean
- [x] New tests: `SystemSecurityPlanExportOfferingsView.spec.ts` (list/create/edit/publish/deprecate/revoke/gating), `ExportOfferingItemsDialog.spec.ts` (add/remove item, gating, revoked-disables-controls), `useOfferableCapabilities.spec.ts` (control-level/statement-level flattening)
- [x] Full `npm run test:unit` suite green aside from one pre-existing, unrelated `LoginView.spec.ts` failure (`localStorage` env issue predating this change)
- [x] Manually verified in a local demo environment (SSP → Export Offerings tab → create → manage items → publish → deprecate/revoke, and permission gating)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Export Offerings section for System Security Plans.
  * Create and edit offerings with titles and descriptions.
  * Add or remove offering items from available capabilities.
  * View offering statuses, versions, descriptions, and publication details.
  * Publish, republish, deprecate, or revoke offerings with confirmation prompts.
  * Added permission-based controls for offering actions.

* **Tests**
  * Added coverage for offering management, item updates, permissions, statuses, and capability discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->