### PR TITLE
BCH-1345: Leverage tab for browsing/subscribing to published export offerings

### DIFF
--- a/src/components/system-security-plans/SubscribeOfferingWizard.vue
+++ b/src/components/system-security-plans/SubscribeOfferingWizard.vue
@@ -173,6 +173,7 @@ function toRfc3339(dateOnly: string): string {
 }
 
 async function submit() {
+  if (submitting.value) return;
   validationError.value = '';
   if (selectedItemIds.value.size === 0) {
     validationError.value = 'Select at least one item to inherit.';

--- a/src/components/system-security-plans/SubscribeOfferingWizard.vue
+++ b/src/components/system-security-plans/SubscribeOfferingWizard.vue
@@ -1,0 +1,230 @@
+<template>
+  <form @submit.prevent="submit" class="space-y-6">
+    <div>
+      <h4 class="text-sm font-medium dark:text-slate-300 mb-2">
+        Items to inherit
+      </h4>
+      <div class="space-y-3">
+        <div
+          v-for="item in offering.items ?? []"
+          :key="item.id"
+          class="p-3 border border-ccf-200 dark:border-slate-600 rounded"
+        >
+          <label class="flex items-center gap-2">
+            <input
+              type="checkbox"
+              :checked="selectedItemIds.has(item.id)"
+              @change="toggleItem(item.id)"
+            />
+            <span class="text-sm dark:text-slate-300">
+              {{ item.controlId
+              }}<span v-if="item.statementId">
+                · Statement {{ item.statementId }}</span
+              >
+            </span>
+          </label>
+
+          <div
+            v-if="selectedItemIds.has(item.id) && item.responsibilities.length"
+            class="mt-2 ml-6 space-y-1"
+          >
+            <div class="text-xs text-gray-500 dark:text-slate-400">
+              Responsibilities we will satisfy:
+            </div>
+            <label
+              v-for="responsibility in item.responsibilities"
+              :key="responsibility.responsibilityUuid"
+              class="flex items-center gap-2"
+            >
+              <input
+                type="checkbox"
+                :checked="
+                  isSatisfied(item.id, responsibility.responsibilityUuid)
+                "
+                @change="
+                  toggleSatisfied(item.id, responsibility.responsibilityUuid)
+                "
+              />
+              <span class="text-sm dark:text-slate-300">
+                {{ responsibility.description }}
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <h4 class="text-sm font-medium dark:text-slate-300 mb-2">
+        Leveraged Authorization
+      </h4>
+      <div class="space-y-3">
+        <div>
+          <Label for="leverage-title" required>Title</Label>
+          <InputText
+            id="leverage-title"
+            v-model="leveragedAuth.title"
+            class="w-full"
+          />
+        </div>
+        <div>
+          <Label for="leverage-party-uuid" required>Party UUID</Label>
+          <InputText
+            id="leverage-party-uuid"
+            v-model="leveragedAuth.partyUuid"
+            placeholder="UUID of the party providing the authorization"
+            class="w-full"
+          />
+        </div>
+        <div>
+          <Label for="leverage-date-authorized">Date Authorized</Label>
+          <input
+            id="leverage-date-authorized"
+            v-model="leveragedAuth.dateAuthorized"
+            type="date"
+            class="w-full p-2 border border-ccf-300 dark:border-slate-700 rounded-md bg-white dark:bg-slate-900 dark:text-slate-300"
+          />
+        </div>
+      </div>
+    </div>
+
+    <Message v-if="validationError" severity="error">
+      {{ validationError }}
+    </Message>
+
+    <div
+      class="flex justify-end gap-3 pt-2 border-t border-gray-200 dark:border-slate-700"
+    >
+      <SecondaryButton type="button" @click="$emit('cancel')">
+        Cancel
+      </SecondaryButton>
+      <PrimaryButton type="submit" :disabled="submitting">
+        {{ submitting ? 'Subscribing...' : 'Subscribe' }}
+      </PrimaryButton>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import InputText from '@/volt/InputText.vue';
+import Label from '@/volt/Label.vue';
+import Message from '@/volt/Message.vue';
+import PrimaryButton from '@/volt/PrimaryButton.vue';
+import SecondaryButton from '@/volt/SecondaryButton.vue';
+import { useAuthenticatedInstance } from '@/composables/axios';
+import type { DataResponse, ErrorBody, ErrorResponse } from '@/stores/types';
+import type { CatalogOffering } from '@/types/ssp-export-offerings';
+import type { SSPLeverageLink, SubscribeRequest } from '@/types/ssp-leverage';
+import type { AxiosError } from 'axios';
+
+const props = defineProps<{
+  sspId: string;
+  offering: CatalogOffering;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  subscribed: [links: SSPLeverageLink[]];
+}>();
+
+const toast = useToast();
+const axiosInstance = useAuthenticatedInstance();
+
+const selectedItemIds = ref(new Set<string>());
+const satisfiedByItem = ref(new Map<string, Set<string>>());
+const leveragedAuth = reactive({
+  title: '',
+  partyUuid: '',
+  dateAuthorized: '',
+});
+const submitting = ref(false);
+const validationError = ref('');
+
+function toggleItem(itemId: string) {
+  if (selectedItemIds.value.has(itemId)) {
+    selectedItemIds.value.delete(itemId);
+  } else {
+    selectedItemIds.value.add(itemId);
+  }
+}
+
+function isSatisfied(itemId: string, responsibilityUuid: string): boolean {
+  return satisfiedByItem.value.get(itemId)?.has(responsibilityUuid) ?? false;
+}
+
+function toggleSatisfied(itemId: string, responsibilityUuid: string) {
+  if (!satisfiedByItem.value.has(itemId)) {
+    satisfiedByItem.value.set(itemId, new Set());
+  }
+  const set = satisfiedByItem.value.get(itemId)!;
+  if (set.has(responsibilityUuid)) {
+    set.delete(responsibilityUuid);
+  } else {
+    set.add(responsibilityUuid);
+  }
+}
+
+// Converts an <input type="date"> value ("YYYY-MM-DD") to a full RFC3339 timestamp —
+// Go's time.Parse(time.RFC3339, ...) rejects a bare date, which is all a date input gives.
+function toRfc3339(dateOnly: string): string {
+  return new Date(dateOnly).toISOString().replace(/\.\d+Z$/, 'Z');
+}
+
+async function submit() {
+  validationError.value = '';
+  if (selectedItemIds.value.size === 0) {
+    validationError.value = 'Select at least one item to inherit.';
+    return;
+  }
+  if (!leveragedAuth.title.trim() || !leveragedAuth.partyUuid.trim()) {
+    validationError.value =
+      'Leveraged Authorization title and Party UUID are required.';
+    return;
+  }
+
+  const body: SubscribeRequest = {
+    downstreamSspId: props.sspId,
+    leveragedAuthorization: {
+      title: leveragedAuth.title.trim(),
+      partyUuid: leveragedAuth.partyUuid.trim(),
+      ...(leveragedAuth.dateAuthorized
+        ? { dateAuthorized: toRfc3339(leveragedAuth.dateAuthorized) }
+        : {}),
+    },
+    items: [...selectedItemIds.value].map((itemId) => ({
+      itemId,
+      satisfiedResponsibilityUuids: [
+        ...(satisfiedByItem.value.get(itemId) ?? []),
+      ],
+    })),
+  };
+
+  submitting.value = true;
+  try {
+    const response = await axiosInstance.post<DataResponse<SSPLeverageLink[]>>(
+      `/api/oscal/ssp-export-offerings/${props.offering.id}/subscribe`,
+      body,
+    );
+    toast.add({
+      severity: 'success',
+      summary: `Subscribed to ${response.data.data.length} item${response.data.data.length === 1 ? '' : 's'}.`,
+      life: 3000,
+    });
+    emit('subscribed', response.data.data);
+  } catch (error) {
+    const errorResponse = error as AxiosError<ErrorResponse<ErrorBody>>;
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail:
+        errorResponse.response?.data?.errors?.body ||
+        'Failed to subscribe to export offering.',
+      life: 5000,
+    });
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>

--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -64,6 +64,7 @@ export const ACTIONS = {
   DELETE: 'delete',
   PROMOTE: 'promote',
   EXPORT: 'export',
+  SUBSCRIBE: 'subscribe',
   INGEST: 'ingest',
   REGISTER: 'register',
   // admin actions
@@ -150,6 +151,7 @@ const ACTION_VERBS: Partial<Record<string, string>> = {
   [ACTIONS.DELETE]: 'delete',
   [ACTIONS.PROMOTE]: 'promote',
   [ACTIONS.EXPORT]: 'publish',
+  [ACTIONS.SUBSCRIBE]: 'subscribe to',
   [ACTIONS.REGISTER]: 'register',
   [ACTIONS.INGEST]: 'ingest',
   [ACTIONS.EXECUTE]: 'import',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -762,6 +762,14 @@ const authenticatedRoutes = [
           ),
       },
       {
+        path: 'leverage',
+        name: 'system-security-plan-leverage',
+        component: () =>
+          import(
+            '../views/system-security-plans/SystemSecurityPlanLeverageView.vue'
+          ),
+      },
+      {
         path: 'risks',
         name: 'system-security-plan-risks',
         component: () => import('../views/RisksView.vue'),

--- a/src/types/ssp-export-offerings.ts
+++ b/src/types/ssp-export-offerings.ts
@@ -31,3 +31,20 @@ export interface SSPExportOffering {
   updatedAt: string;
   items?: SSPExportOfferingItem[];
 }
+
+// The flat, cross-SSP catalog (GET /oscal/ssp-export-offerings) resolves each item's
+// upstream responsibilities server-side, but deliberately omits any upstream SSP
+// title/metadata — only a bare sspId. Never resolve that into a friendly name (would
+// require ssp:read on the upstream SSP, the exact trust boundary BCH-1345 must not cross).
+export interface UpstreamResponsibility {
+  responsibilityUuid: string;
+  description: string;
+}
+
+export interface CatalogOfferingItem extends SSPExportOfferingItem {
+  responsibilities: UpstreamResponsibility[];
+}
+
+export interface CatalogOffering extends Omit<SSPExportOffering, 'items'> {
+  items?: CatalogOfferingItem[];
+}

--- a/src/types/ssp-leverage.ts
+++ b/src/types/ssp-leverage.ts
@@ -1,0 +1,38 @@
+// Types for the downstream SSP leverage/subscribe endpoints (BCH-1338). Hand-written,
+// camelCase JSON — not OSCAL — so requests must not use decamelizeKeys.
+
+export type SSPLeverageSatisfaction = 'full' | 'partial';
+
+export type SSPLeverageStatus = 'active' | 'drifted' | 'revoked' | 'superseded';
+
+export interface SSPLeverageLink {
+  id: string;
+  downstreamSspId: string;
+  upstreamSspId: string;
+  offeringId: string;
+  offeringVersion: number;
+  controlId: string;
+  statementId?: string;
+  providedUuid: string;
+  inheritedUuid: string;
+  leveragedAuthUuid: string;
+  satisfaction: SSPLeverageSatisfaction;
+  status: SSPLeverageStatus;
+  attestedAt?: string;
+  attestedById?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SubscribeRequest {
+  downstreamSspId: string;
+  leveragedAuthorization: {
+    title: string;
+    partyUuid: string;
+    dateAuthorized?: string;
+  };
+  items: Array<{
+    itemId: string;
+    satisfiedResponsibilityUuids?: string[];
+  }>;
+}

--- a/src/views/system-security-plans/SystemSecurityPlanEditorView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanEditorView.vue
@@ -62,6 +62,15 @@
       </RouterLink>
       <RouterLink
         class="tab-link px-4 py-2 inline-block text-lg border-ccf-300 dark:border-slate-700 dark:hover:bg-slate-900"
+        :to="{
+          name: 'system-security-plan-leverage',
+          params: { id: sspId },
+        }"
+      >
+        Leverage
+      </RouterLink>
+      <RouterLink
+        class="tab-link px-4 py-2 inline-block text-lg border-ccf-300 dark:border-slate-700 dark:hover:bg-slate-900"
         :to="{ name: 'system-security-plan-risks', params: { id: sspId } }"
       >
         Risks

--- a/src/views/system-security-plans/SystemSecurityPlanLeverageView.vue
+++ b/src/views/system-security-plans/SystemSecurityPlanLeverageView.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="space-y-6">
+    <div
+      class="bg-white dark:bg-slate-900 border border-ccf-300 dark:border-slate-700 rounded-lg p-6"
+    >
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-slate-300 mb-4">
+        Leverage
+      </h3>
+
+      <div v-if="loading" class="text-center py-4">
+        <p class="text-gray-500 dark:text-slate-400">
+          Loading published export offerings...
+        </p>
+      </div>
+
+      <div v-else-if="!offerings?.length" class="text-center py-8">
+        <p class="text-gray-500 dark:text-slate-400">
+          No published export offerings available yet.
+        </p>
+      </div>
+
+      <div v-else class="space-y-4">
+        <div
+          v-for="offering in offerings"
+          :key="offering.id"
+          class="border border-gray-200 dark:border-slate-700 rounded-lg p-4"
+        >
+          <div class="flex justify-between items-start mb-2">
+            <div>
+              <div class="flex items-center gap-2">
+                <h4 class="font-medium text-gray-900 dark:text-slate-300">
+                  {{ offering.title }}
+                </h4>
+                <span class="text-xs text-gray-500 dark:text-slate-400">
+                  v{{ offering.version }}
+                </span>
+              </div>
+              <p
+                v-if="offering.description"
+                class="text-sm text-gray-600 dark:text-slate-400 mt-1"
+              >
+                {{ offering.description }}
+              </p>
+              <p class="text-xs text-gray-500 dark:text-slate-400 mt-1">
+                {{ itemSummary(offering) }}
+              </p>
+            </div>
+            <PermissionGate
+              :resource="RESOURCES.SSP_EXPORT_OFFERING"
+              :action="ACTIONS.SUBSCRIBE"
+            >
+              <PermissionGate
+                :resource="RESOURCES.SSP"
+                :action="ACTIONS.UPDATE"
+              >
+                <SecondaryButton
+                  type="button"
+                  size="small"
+                  @click="openSubscribeModal(offering)"
+                >
+                  Subscribe
+                </SecondaryButton>
+              </PermissionGate>
+            </PermissionGate>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <Dialog
+      v-model:visible="showSubscribeModal"
+      size="xl"
+      modal
+      :header="`Subscribe — ${subscribingOffering?.title ?? ''}`"
+    >
+      <SubscribeOfferingWizard
+        v-if="subscribingOffering"
+        :ssp-id="sspId"
+        :offering="subscribingOffering"
+        @cancel="showSubscribeModal = false"
+        @subscribed="handleSubscribed"
+      />
+    </Dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import Dialog from '@/volt/Dialog.vue';
+import SecondaryButton from '@/volt/SecondaryButton.vue';
+import PermissionGate from '@/components/auth/PermissionGate.vue';
+import SubscribeOfferingWizard from '@/components/system-security-plans/SubscribeOfferingWizard.vue';
+import { RESOURCES, ACTIONS } from '@/constants/permissions';
+import { useDataApi } from '@/composables/axios';
+import { getIdFromRoute } from '@/utils/get-poam-id-from-route';
+import type { CatalogOffering } from '@/types/ssp-export-offerings';
+import type { SSPLeverageLink } from '@/types/ssp-leverage';
+
+const route = useRoute();
+const sspId = computed(() => getIdFromRoute(route) ?? '');
+
+// The catalog is the only fetch this view makes — deliberately: it already omits any
+// upstream SSP title/metadata, so there is nothing here to join against an
+// upstream-scoped endpoint (which would require ssp:read on the upstream SSP, the exact
+// trust boundary this ticket must not cross).
+const { data: offerings, isLoading: loading } = useDataApi<CatalogOffering[]>(
+  '/api/oscal/ssp-export-offerings',
+);
+
+const showSubscribeModal = ref(false);
+const subscribingOffering = ref<CatalogOffering | null>(null);
+
+function itemSummary(offering: CatalogOffering): string {
+  const items = offering.items ?? [];
+  if (!items.length) return 'No items';
+  const controlIds = [...new Set(items.map((item) => item.controlId))];
+  const shown = controlIds.slice(0, 3).join(', ');
+  const remaining = controlIds.length - 3;
+  const suffix = remaining > 0 ? ` (+${remaining} more)` : '';
+  return `${items.length} item${items.length === 1 ? '' : 's'}: ${shown}${suffix}`;
+}
+
+function openSubscribeModal(offering: CatalogOffering) {
+  subscribingOffering.value = offering;
+  showSubscribeModal.value = true;
+}
+
+function handleSubscribed(links: SSPLeverageLink[]) {
+  void links;
+  showSubscribeModal.value = false;
+  subscribingOffering.value = null;
+}
+</script>

--- a/src/views/system-security-plans/__tests__/SystemSecurityPlanLeverageView.spec.ts
+++ b/src/views/system-security-plans/__tests__/SystemSecurityPlanLeverageView.spec.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import SystemSecurityPlanLeverageView from '../SystemSecurityPlanLeverageView.vue';
+import { RESOURCES, ACTIONS } from '@/constants/permissions';
+import type { CatalogOffering } from '@/types/ssp-export-offerings';
+
+const { postMock, toastAddMock, permState, offeringsData } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  toastAddMock: vi.fn(),
+  permState: { canSubscribe: true, canUpdateSsp: true },
+  offeringsData: { current: [] as CatalogOffering[] },
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: 'ssp-downstream-1' } }),
+}));
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: toastAddMock }),
+}));
+
+vi.mock('@/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => {
+      if (
+        resource === RESOURCES.SSP_EXPORT_OFFERING &&
+        action === ACTIONS.SUBSCRIBE
+      ) {
+        return permState.canSubscribe;
+      }
+      if (resource === RESOURCES.SSP && action === ACTIONS.UPDATE) {
+        return permState.canUpdateSsp;
+      }
+      return true;
+    },
+    permissionTooltip: () => '',
+  }),
+}));
+
+const fetchedUrls: string[] = [];
+vi.mock('@/composables/axios', async () => {
+  const { ref } = await import('vue');
+  return {
+    useDataApi: (url: string) => {
+      fetchedUrls.push(url);
+      return { data: ref(offeringsData.current), isLoading: ref(false) };
+    },
+    useAuthenticatedInstance: () => ({ post: postMock }),
+  };
+});
+
+const stubs = {
+  Dialog: {
+    props: ['visible'],
+    template: '<div v-if="visible"><slot /></div>',
+  },
+  PrimaryButton: {
+    props: ['disabled'],
+    emits: ['click'],
+    template:
+      '<button :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  SecondaryButton: {
+    emits: ['click'],
+    template: '<button @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  InputText: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template:
+      '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  Label: { template: '<label><slot /></label>' },
+  Message: { template: '<div class="message"><slot /></div>' },
+};
+
+function makeOffering(
+  overrides: Partial<CatalogOffering> = {},
+): CatalogOffering {
+  return {
+    id: 'offering-1',
+    sspId: 'ssp-upstream-1',
+    title: 'GovCloud Baseline',
+    description: 'A useful offering',
+    version: 2,
+    status: 'published',
+    contentHash: '',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    items: [
+      {
+        id: 'item-1',
+        offeringId: 'offering-1',
+        controlId: 'ac-1',
+        componentUuid: 'comp-1',
+        providedUuid: 'p-1',
+        responsibilities: [
+          { responsibilityUuid: 'r-1', description: 'Rotate credentials' },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function findButton(wrapper: ReturnType<typeof mount>, text: string) {
+  const button = wrapper.findAll('button').find((b) => b.text() === text);
+  if (!button) throw new Error(`Button with text "${text}" not found`);
+  return button;
+}
+
+function mountView() {
+  return mount(SystemSecurityPlanLeverageView, { global: { stubs } });
+}
+
+describe('SystemSecurityPlanLeverageView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permState.canSubscribe = true;
+    permState.canUpdateSsp = true;
+    offeringsData.current = [];
+    fetchedUrls.length = 0;
+    postMock.mockResolvedValue({ data: { data: [] } });
+  });
+
+  it('renders an empty state when there are no published offerings', () => {
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain(
+      'No published export offerings available yet.',
+    );
+  });
+
+  it('renders an offering with title, version, and item summary', () => {
+    offeringsData.current = [makeOffering()];
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain('GovCloud Baseline');
+    expect(wrapper.text()).toContain('v2');
+    expect(wrapper.text()).toContain('1 item: ac-1');
+  });
+
+  it('never fetches anything upstream-scoped — only the flat catalog', () => {
+    offeringsData.current = [makeOffering()];
+    mountView();
+    expect(fetchedUrls).toEqual(['/api/oscal/ssp-export-offerings']);
+    for (const url of fetchedUrls) {
+      expect(url).not.toContain('ssp-upstream-1');
+      expect(url).not.toMatch(/system-security-plans\/(?!undefined)/);
+    }
+  });
+
+  it('subscribes to selected items with satisfied responsibilities', async () => {
+    offeringsData.current = [makeOffering()];
+    postMock.mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            id: 'link-1',
+            downstreamSspId: 'ssp-downstream-1',
+            upstreamSspId: 'ssp-upstream-1',
+            offeringId: 'offering-1',
+            offeringVersion: 2,
+            controlId: 'ac-1',
+            providedUuid: 'p-1',
+            inheritedUuid: 'inherited-1',
+            leveragedAuthUuid: 'auth-1',
+            satisfaction: 'full',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      },
+    });
+
+    const wrapper = mountView();
+    await findButton(wrapper, 'Subscribe').trigger('click');
+
+    const itemCheckbox = wrapper.find('input[type="checkbox"]');
+    await itemCheckbox.setValue(true);
+
+    const responsibilityCheckboxes = wrapper.findAll('input[type="checkbox"]');
+    await responsibilityCheckboxes[1].setValue(true);
+
+    const inputs = wrapper.findAll(
+      'input:not([type="checkbox"]):not([type="date"])',
+    );
+    await inputs[0].setValue('My Leveraged Auth');
+    await inputs[1].setValue('11111111-1111-1111-1111-111111111111');
+
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oscal/ssp-export-offerings/offering-1/subscribe',
+      {
+        downstreamSspId: 'ssp-downstream-1',
+        leveragedAuthorization: {
+          title: 'My Leveraged Auth',
+          partyUuid: '11111111-1111-1111-1111-111111111111',
+        },
+        items: [{ itemId: 'item-1', satisfiedResponsibilityUuids: ['r-1'] }],
+      },
+    );
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' }),
+    );
+  });
+
+  it('blocks submitting with zero items selected', async () => {
+    offeringsData.current = [makeOffering()];
+    const wrapper = mountView();
+    await findButton(wrapper, 'Subscribe').trigger('click');
+
+    const inputs = wrapper.findAll(
+      'input:not([type="checkbox"]):not([type="date"])',
+    );
+    await inputs[0].setValue('My Leveraged Auth');
+    await inputs[1].setValue('11111111-1111-1111-1111-111111111111');
+
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Select at least one item to inherit.');
+  });
+
+  it('hides Subscribe without ssp-export-offering:subscribe', () => {
+    permState.canSubscribe = false;
+    offeringsData.current = [makeOffering()];
+    const wrapper = mountView();
+    expect(wrapper.findAll('button').map((b) => b.text())).not.toContain(
+      'Subscribe',
+    );
+  });
+
+  it('hides Subscribe without ssp:update on the current SSP', () => {
+    permState.canUpdateSsp = false;
+    offeringsData.current = [makeOffering()];
+    const wrapper = mountView();
+    expect(wrapper.findAll('button').map((b) => b.text())).not.toContain(
+      'Subscribe',
+    );
+  });
+
+  it('hides Subscribe when both permissions are denied', () => {
+    permState.canSubscribe = false;
+    permState.canUpdateSsp = false;
+    offeringsData.current = [makeOffering()];
+    const wrapper = mountView();
+    expect(wrapper.findAll('button').map((b) => b.text())).not.toContain(
+      'Subscribe',
+    );
+  });
+});

--- a/src/views/system-security-plans/__tests__/SystemSecurityPlanLeverageView.spec.ts
+++ b/src/views/system-security-plans/__tests__/SystemSecurityPlanLeverageView.spec.ts
@@ -4,6 +4,8 @@ import SystemSecurityPlanLeverageView from '../SystemSecurityPlanLeverageView.vu
 import { RESOURCES, ACTIONS } from '@/constants/permissions';
 import type { CatalogOffering } from '@/types/ssp-export-offerings';
 
+const UPSTREAM_SCOPED_SSP_PATH = /system-security-plans\/(?!undefined)/;
+
 const { postMock, toastAddMock, permState, offeringsData } = vi.hoisted(() => ({
   postMock: vi.fn(),
   toastAddMock: vi.fn(),
@@ -144,7 +146,7 @@ describe('SystemSecurityPlanLeverageView', () => {
     expect(fetchedUrls).toEqual(['/api/oscal/ssp-export-offerings']);
     for (const url of fetchedUrls) {
       expect(url).not.toContain('ssp-upstream-1');
-      expect(url).not.toMatch(/system-security-plans\/(?!undefined)/);
+      expect(url).not.toMatch(UPSTREAM_SCOPED_SSP_PATH);
     }
   });
 


### PR DESCRIPTION
## Summary
- New "Leverage" tab on the SSP editor: browse published export offerings from the cross-SSP catalog (`GET /oscal/ssp-export-offerings`) — title, description, version, and an item-count summary. Never surfaces anything upstream-scoped (no upstream SSP name/metadata is available in the catalog response by design, and this view never fetches one).
- Subscribe wizard: pick which offering items to inherit, mark which upstream responsibilities the downstream will satisfy per item, and supply Leveraged Authorization details (title, party UUID, optional date). Posts to `POST /oscal/ssp-export-offerings/:id/subscribe` (BCH-1338).
- Subscribe is gated behind **both** `ssp-export-offering:subscribe` and `ssp:update` (on the current/downstream SSP) via nested `PermissionGate`s — mirroring the API's own dual server-side check, which also never evaluates `ssp:read` on the upstream SSP anywhere in the path.
- New `SUBSCRIBE` permission action constant, and `CatalogOffering`/`CatalogOfferingItem`/`SSPLeverageLink`/`SubscribeRequest` types matching the API's actual JSON shapes.

## Test plan
- [x] `vue-tsc --build` clean (project-wide, including test files)
- [x] `eslint` clean
- [x] New tests (`SystemSecurityPlanLeverageView.spec.ts`): offering list rendering, empty state, a dedicated trust-boundary test asserting the *only* URL ever fetched is the flat catalog endpoint, full subscribe round-trip (payload shape + success toast), blocked submit with zero items selected, and gating on either/both permissions
- [x] Full `npm run test:unit` suite green aside from one pre-existing, unrelated `LoginView.spec.ts` failure (`localStorage` env issue predating this change)
- [x] Manually verified in a local demo environment: published a real offering on one SSP, subscribed from another, and confirmed via the (BCH-1338/1341) projection endpoint that the inherited claim, satisfied responsibility, and leveraged authorization were all created correctly with satisfaction computed as `full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Leverage tab for browsing available security plan offerings.
  * Added offering details, item selection, responsibility tracking, and authorization fields.
  * Added subscription workflow with validation, progress feedback, success and error notifications.
  * Added permission controls for viewing and subscribing to offerings.
  * Added support for catalog offering and leverage subscription data.

* **Tests**
  * Added coverage for offering display, subscription submission, validation, permissions, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->